### PR TITLE
fix(sshconfig): change ssh config for more restrictions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ RUN sed -i 's/^#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config \
     && sed -i 's/^#PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config \
     && sed -i 's/^#LogLevel.*/LogLevel VERBOSE/' /etc/ssh/sshd_config \
     && sed -i 's/^#SyslogFacility.*/SyslogFacility AUTH/' /etc/ssh/sshd_config \
-    && sed -i 's|^Subsystem sftp.*|#Subsystem sftp internal-sftp|' /etc/ssh/sshd_config \
+    && sed -i 's|^Subsystem|#Subsystem|' /etc/ssh/sshd_config \
+    && sed -i 's|^#AllowAgentForwarding.*|AllowAgentForwarding no|' /etc/ssh/sshd_config \
+    && sed -i 's|^#PubkeyAuthentication.*|PubkeyAuthentication yes|' /etc/ssh/sshd_config \
     && echo 'ForceCommand /app/goBastion "$SSH_ORIGINAL_COMMAND"' >> /etc/ssh/sshd_config
 
 COPY --from=builder /app/goBastion /app/goBastion


### PR DESCRIPTION
SSH configuration updates:

* Changed the `Subsystem` directive to comment out all subsystem configurations instead of only `sftp`, enhancing flexibility in SSH configuration.
* Added a directive to disable agent forwarding (`AllowAgentForwarding no`) for improved security.
* Force public key authentication (`PubkeyAuthentication yes`) to support secure key-based logins.