### PR TITLE
fix(typo): change name of function and right

### DIFF
--- a/commands/group.go
+++ b/commands/group.go
@@ -661,8 +661,8 @@ func GroupDelAccess(db *gorm.DB, currentUser *models.User, args []string) error 
 	return nil
 }
 
-func GroupListAccess(db *gorm.DB, currentUser *models.User, args []string) error {
-	fs := flag.NewFlagSet("groupListAccess", flag.ContinueOnError)
+func GroupListAccesses(db *gorm.DB, currentUser *models.User, args []string) error {
+	fs := flag.NewFlagSet("groupListAccesses", flag.ContinueOnError)
 	var groupName string
 	fs.StringVar(&groupName, "group", "", "Group name")
 	var flagOutput bytes.Buffer

--- a/commands/help.go
+++ b/commands/help.go
@@ -47,7 +47,7 @@ func DisplayHelp(db *gorm.DB, user models.User) {
 		Body: []string{
 			" " + utils.FgGreen("-") + " selfListEgressKeys             List your egress keys",
 			" " + utils.FgGreen("-") + " selfGenerateEgressKey          Generate a new egress key",
-			" " + utils.FgGreen("-") + " selfRemoveHostFromKnownHosts   Remove Host to Known_hosts file",
+			" " + utils.FgGreen("-") + " selfRemoveHostFromKnownHosts   Remove host from Known_hosts file",
 		},
 	})
 	sections = append(sections, console.SectionContent{
@@ -78,7 +78,7 @@ func DisplayHelp(db *gorm.DB, user models.User) {
 		SubSubTitle:   "",
 		Body: []string{
 			" " + utils.FgGreen("-") + " ttyList                   List recorded tty sessions",
-			" " + utils.FgGreen("-") + " ttyPlay                   Read a recorded tty session",
+			" " + utils.FgGreen("-") + " ttyPlay                   Replay a recorded tty session",
 		},
 	})
 
@@ -163,7 +163,7 @@ func DisplayHelp(db *gorm.DB, user models.User) {
 			SubTitleColor: utils.FgWhiteB,
 			SubSubTitle:   " Group accesses:",
 			Body: []string{
-				" " + utils.FgGreen("-") + " groupListAccess         List access of the group",
+				" " + utils.FgGreen("-") + " groupListAccesses         List accesses of the group",
 				" " + utils.FgGreen("-") + " groupAddAccess          Add access to a group",
 				" " + utils.FgGreen("-") + " groupDelAccess          Remove access from a group",
 			},

--- a/main.go
+++ b/main.go
@@ -505,7 +505,7 @@ func executeCommand(db *gorm.DB, currentUser *models.User, log *slog.Logger, cmd
 			log.Error("groupListEgressKeys error", slog.String("error", err.Error()))
 		}
 	case "groupListAccess":
-		if err := commands.GroupListAccess(db, currentUser, args); err != nil {
+		if err := commands.GroupListAccesses(db, currentUser, args); err != nil {
 			log.Error("groupListAccess error", slog.String("error", err.Error()))
 		}
 	case "groupAddAlias":

--- a/utils/autocomplete/autocomplete.go
+++ b/utils/autocomplete/autocomplete.go
@@ -89,46 +89,52 @@ func Completion(d prompt.Document, user *models.User) []prompt.Suggest {
 			}
 			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
 		case "accountCreate":
-			if user.Role != "admin" {
-				return []prompt.Suggest{}
-			}
 			sugs := []prompt.Suggest{
 				{Text: "--user", Description: "Username to create"},
 			}
-			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
-		case "accountModify":
 			if user.Role != "admin" {
 				return []prompt.Suggest{}
 			}
+			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
+		case "accountModify":
 			sugs := []prompt.Suggest{
 				{Text: "--user", Description: "Username to modify"},
 				{Text: "--role", Description: "New role (admin or user)"},
 			}
-			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
-		case "accountDelete":
 			if user.Role != "admin" {
 				return []prompt.Suggest{}
 			}
+			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
+		case "accountDelete":
 			sugs := []prompt.Suggest{
 				{Text: "--user", Description: "Username to delete"},
+			}
+			if user.Role != "admin" {
+				return []prompt.Suggest{}
 			}
 			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
 		case "accountListIngressKeys":
 			sugs := []prompt.Suggest{
 				{Text: "--user", Description: "Username to list ingress keys"},
 			}
-			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
-		case "accountListEgressKeys":
 			if user.Role != "admin" {
 				return []prompt.Suggest{}
 			}
+			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
+		case "accountListEgressKeys":
 			sugs := []prompt.Suggest{
 				{Text: "--user", Description: "Username to list egress keys"},
+			}
+			if user.Role != "admin" {
+				return []prompt.Suggest{}
 			}
 			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
 		case "accountListAccess":
 			sugs := []prompt.Suggest{
 				{Text: "--user", Description: "Username to list accesses"},
+			}
+			if user.Role != "admin" {
+				return []prompt.Suggest{}
 			}
 			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
 		case "accountAddAccess":
@@ -139,10 +145,16 @@ func Completion(d prompt.Document, user *models.User) []prompt.Suggest {
 				{Text: "--username", Description: "SSH Username"},
 				{Text: "--comment", Description: "Comment"},
 			}
+			if user.Role != "admin" {
+				return []prompt.Suggest{}
+			}
 			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
 		case "accountDelAccess":
 			sugs := []prompt.Suggest{
 				{Text: "--access", Description: "Access ID"},
+			}
+			if user.Role != "admin" {
+				return []prompt.Suggest{}
 			}
 			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
 
@@ -158,19 +170,19 @@ func Completion(d prompt.Document, user *models.User) []prompt.Suggest {
 			}
 			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
 		case "groupCreate":
-			if user.Role != "admin" {
-				return []prompt.Suggest{}
-			}
 			sugs := []prompt.Suggest{
 				{Text: "--group", Description: "Group name"},
+			}
+			if user.Role != "admin" {
+				return []prompt.Suggest{}
 			}
 			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
 		case "groupDelete":
-			if user.Role != "admin" {
-				return []prompt.Suggest{}
-			}
 			sugs := []prompt.Suggest{
 				{Text: "--group", Description: "Group name"},
+			}
+			if user.Role != "admin" && !isGroupManager(user) {
+				return []prompt.Suggest{}
 			}
 			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
 		case "groupAddAccess":
@@ -181,16 +193,25 @@ func Completion(d prompt.Document, user *models.User) []prompt.Suggest {
 				{Text: "--username", Description: "SSH username"},
 				{Text: "--comment", Description: "Comment"},
 			}
+			if user.Role != "admin" && !isGroupManager(user) {
+				return []prompt.Suggest{}
+			}
 			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
 		case "groupDelAccess":
 			sugs := []prompt.Suggest{
 				{Text: "--group", Description: "Group name"},
 				{Text: "--access", Description: "Access ID to remove"},
 			}
+			if user.Role != "admin" && !isGroupManager(user) {
+				return []prompt.Suggest{}
+			}
 			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
-		case "groupListAccess":
+		case "groupListAccesses":
 			sugs := []prompt.Suggest{
 				{Text: "--group", Description: "Group name"},
+			}
+			if user.Role != "admin" && !isGroupManager(user) {
+				return []prompt.Suggest{}
 			}
 			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
 		case "groupAddMember":
@@ -234,16 +255,25 @@ func Completion(d prompt.Document, user *models.User) []prompt.Suggest {
 				{Text: "--alias", Description: "Alias"},
 				{Text: "--hostname", Description: "Host name"},
 			}
+			if user.Role != "admin" && !isGroupManager(user) {
+				return []prompt.Suggest{}
+			}
 			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
 		case "groupDelAlias":
 			sugs := []prompt.Suggest{
 				{Text: "--group", Description: "Group name"},
 				{Text: "--id", Description: "Alias ID"},
 			}
+			if user.Role != "admin" && !isGroupManager(user) {
+				return []prompt.Suggest{}
+			}
 			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
 		case "groupListAliases":
 			sugs := []prompt.Suggest{
 				{Text: "--group", Description: "Group name"},
+			}
+			if user.Role != "admin" && !isGroupMember(user) {
+				return []prompt.Suggest{}
 			}
 			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
 
@@ -266,6 +296,9 @@ func Completion(d prompt.Document, user *models.User) []prompt.Suggest {
 		case "whoHasAccessTo":
 			sugs := []prompt.Suggest{
 				{Text: "--server", Description: "Server"},
+			}
+			if user.Role != "admin" {
+				return []prompt.Suggest{}
 			}
 			return prompt.FilterHasPrefix(filterAlreadyUsed(sugs), d.GetWordBeforeCursor(), true)
 
@@ -311,7 +344,7 @@ func Completion(d prompt.Document, user *models.User) []prompt.Suggest {
 			{Text: "groupGenerateEgressKey", Description: "Generate group egress key"},
 			{Text: "groupAddAccess", Description: "Add access to a group"},
 			{Text: "groupDelAccess", Description: "Remove access from a group"},
-			{Text: "groupListAccess", Description: "List group accesses"},
+			{Text: "groupListAccesses", Description: "List group accesses"},
 			{Text: "groupAddAlias", Description: "Add an alias to a group"},
 			{Text: "groupDelAlias", Description: "Delete an alias from a group"},
 			{Text: "groupListAliases", Description: "List group aliases"},
@@ -320,17 +353,17 @@ func Completion(d prompt.Document, user *models.User) []prompt.Suggest {
 		groupSuggestions = []prompt.Suggest{
 			{Text: "groupInfo", Description: "Show group info"},
 			{Text: "groupList", Description: "List groups"},
+			{Text: "groupListAliases", Description: "List group aliases"},
 		}
 		if isGroupManager(user) {
 			groupSuggestions = append(groupSuggestions, []prompt.Suggest{
 				{Text: "groupAddAccess", Description: "Add access to a group"},
 				{Text: "groupDelAccess", Description: "Remove access from a group"},
-				{Text: "groupListAccess", Description: "List group accesses"},
+				{Text: "groupListAccesses", Description: "List group accesses"},
 				{Text: "groupAddMember", Description: "Add a member to a group"},
 				{Text: "groupDelMember", Description: "Remove a member from a group"},
 				{Text: "groupAddAlias", Description: "Add an alias to a group"},
 				{Text: "groupDelAlias", Description: "Delete an alias from a group"},
-				{Text: "groupListAliases", Description: "List group aliases"},
 				{Text: "groupGenerateEgressKey", Description: "Generate group egress key"},
 			}...)
 		}


### PR DESCRIPTION
* Renamed `groupListAccess` to `groupListAccesses` across multiple files for better naming consistency (`commands/group.go`, `main.go`, `utils/autocomplete/autocomplete.go`).
* Updated help text descriptions for commands to improve clarity, such as changing "Read a recorded tty session" to "Replay a recorded tty session" (`commands/help.go`).
* Adjusted phrasing in other help text, e.g., "Remove Host to Known_hosts file" changed to "Remove host from Known_hosts file" (`commands/help.go`).
* Added role-based restrictions to autocomplete suggestions, ensuring that commands like `accountCreate`, `groupDelete`, and `groupDelAccess` are only suggested to users with appropriate roles (`utils/autocomplete/autocomplete.go`).
* Included additional checks for group manager roles in commands related to group management (`utils/autocomplete/autocomplete.go`).