### PR TITLE
chore(role): uniformize role, system role

### DIFF
--- a/commands/account.go
+++ b/commands/account.go
@@ -69,7 +69,7 @@ func AccountList(db *gorm.DB, currentUser *models.User) error {
 
 		userInfo := []string{
 			fmt.Sprintf("Username: %s", u.Username),
-			fmt.Sprintf("Role: %s", u.Role),
+			fmt.Sprintf("System Role: %s", u.Role),
 			fmt.Sprintf("Created At: %s", u.CreatedAt.Format("2006-01-02 15:04:05")),
 			fmt.Sprintf("Last Login: %s", u.LastLoginAt),
 			fmt.Sprintf("Last Login From: %s", u.LastLoginFrom),
@@ -78,7 +78,7 @@ func AccountList(db *gorm.DB, currentUser *models.User) error {
 		if len(userGroups) > 0 {
 			groupLines := []string{"Groups:"}
 			for _, ug := range userGroups {
-				groupLines = append(groupLines, fmt.Sprintf("  - %s (%s)", ug.Group.Name, utils.GetGrades(ug)))
+				groupLines = append(groupLines, fmt.Sprintf("  - %s (%s)", ug.Group.Name, utils.GetRoles(ug)))
 			}
 			userInfo = append(userInfo, groupLines...)
 		}
@@ -163,7 +163,7 @@ func AccountInfo(db *gorm.DB, currentUser *models.User, args []string) error {
 	infoLines := []string{
 		fmt.Sprintf("ID: %s", user.ID.String()),
 		fmt.Sprintf("Username: %s", user.Username),
-		fmt.Sprintf("Role: %s", user.Role),
+		fmt.Sprintf("System Role: %s", user.Role),
 		fmt.Sprintf("Created At: %s", user.CreatedAt.Format("2006-01-02 15:04:05")),
 		fmt.Sprintf("Last Login: %s", user.LastLoginAt),
 		fmt.Sprintf("Last Login From: %s", user.LastLoginFrom),
@@ -174,7 +174,20 @@ func AccountInfo(db *gorm.DB, currentUser *models.User, args []string) error {
 		infoLines = append(infoLines, "	User isn't a member of any groups. 😭")
 	} else {
 		for _, ug := range userGroups {
-			infoLines = append(infoLines, fmt.Sprintf("	* %s - %s", ug.Group.Name, utils.GetGrades(ug)))
+
+			myRoles := utils.GetRoles(ug)
+			roleColored := utils.BgBlueB("Member")
+			if myRoles == "Owner" {
+				roleColored = utils.BgRedB("Owner")
+			}
+			if myRoles == "ACL Keeper" {
+				roleColored = utils.BgYellowB("ACL Keeper")
+			}
+			if myRoles == "Gate Keeper" {
+				roleColored = utils.BgGreenB("Gate Keeper")
+			}
+			
+			infoLines = append(infoLines, fmt.Sprintf("	* %s - %s", ug.Group.Name, roleColored))
 		}
 	}
 
@@ -273,7 +286,7 @@ func AccountModify(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("accountModify", flag.ContinueOnError)
 	var username, newRole string
 	fs.StringVar(&username, "user", "", "Username to modify")
-	fs.StringVar(&newRole, "role", "", "New role (admin or user)")
+	fs.StringVar(&newRole, "sysrole", "", "New system role (admin or user)")
 	var flagOutput bytes.Buffer
 	fs.SetOutput(&flagOutput)
 
@@ -281,7 +294,7 @@ func AccountModify(db *gorm.DB, currentUser *models.User, args []string) error {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Account Modify",
 			BlockType: "error",
-			Sections:  []console.SectionContent{{SubTitle: "Usage Error", Body: []string{"Usage: accountModify --user <username> --role <admin|user>"}}},
+			Sections:  []console.SectionContent{{SubTitle: "Usage Error", Body: []string{"Usage: accountModify --user <username> --sysrole <admin|user>"}}},
 		})
 		return err
 	}
@@ -290,7 +303,7 @@ func AccountModify(db *gorm.DB, currentUser *models.User, args []string) error {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Account Modify",
 			BlockType: "error",
-			Sections:  []console.SectionContent{{SubTitle: "Usage", Body: []string{"Usage: accountModify --user <username> --role <admin|user>"}}},
+			Sections:  []console.SectionContent{{SubTitle: "Usage", Body: []string{"Usage: accountModify --user <username> --sysrole <admin|user>"}}},
 		})
 		return nil
 	}
@@ -309,7 +322,7 @@ func AccountModify(db *gorm.DB, currentUser *models.User, args []string) error {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Account Modify",
 			BlockType: "error",
-			Sections:  []console.SectionContent{{SubTitle: "Invalid Role", Body: []string{"Role must be 'admin' or 'user'."}}},
+			Sections:  []console.SectionContent{{SubTitle: "Invalid System Role", Body: []string{"System role must be 'admin' or 'user'."}}},
 		})
 		return nil
 	}
@@ -329,7 +342,7 @@ func AccountModify(db *gorm.DB, currentUser *models.User, args []string) error {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Account Modify",
 			BlockType: "error",
-			Sections:  []console.SectionContent{{SubTitle: "Error", Body: []string{"Failed to update user role."}}},
+			Sections:  []console.SectionContent{{SubTitle: "Error", Body: []string{"Failed to update user system role."}}},
 		})
 		return err
 	}
@@ -338,7 +351,7 @@ func AccountModify(db *gorm.DB, currentUser *models.User, args []string) error {
 	console.DisplayBlock(console.ContentBlock{
 		Title:     "Account Modify",
 		BlockType: "success",
-		Sections:  []console.SectionContent{{SubTitle: "Success", Body: []string{fmt.Sprintf("User '%s' role updated to '%s'.", username, newRole)}}},
+		Sections:  []console.SectionContent{{SubTitle: "Success", Body: []string{fmt.Sprintf("User '%s' system role updated to '%s'.", username, newRole)}}},
 	})
 
 	return nil
@@ -711,7 +724,7 @@ func WhoHasAccessTo(db *gorm.DB, currentUser *models.User, args []string) error 
 
 	var buf bytes.Buffer
 	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "Type\tName\tUsername\tGrade")
+	_, _ = fmt.Fprintln(w, "Type\tName\tUsername\tRole")
 
 	for _, access := range accesses {
 		if access.User.ID != uuid.Nil {
@@ -727,7 +740,7 @@ func WhoHasAccessTo(db *gorm.DB, currentUser *models.User, args []string) error 
 		}
 		for _, ug := range userGroups {
 			if ug.User.ID != uuid.Nil {
-				_, _ = fmt.Fprintf(w, "-\t-\t%s\t%s\n", ug.User.Username, utils.GetGrades(ug))
+				_, _ = fmt.Fprintf(w, "-\t-\t%s\t%s\n", ug.User.Username, utils.GetRoles(ug))
 			}
 		}
 	}

--- a/commands/group.go
+++ b/commands/group.go
@@ -70,7 +70,19 @@ func GroupInfo(db *gorm.DB, currentUser *models.User, args []string) error {
 	if len(userGroups) > 0 {
 		infoLines = append(infoLines, "Members:")
 		for _, ug := range userGroups {
-			infoLines = append(infoLines, fmt.Sprintf("- %s (%s)", ug.User.Username, utils.GetGrades(ug)))
+			myRoles := utils.GetRoles(ug)
+			roleColored := utils.BgBlueB("Member")
+			if myRoles == "Owner" {
+				roleColored = utils.BgRedB("Owner")
+			}
+			if myRoles == "ACL Keeper" {
+				roleColored = utils.BgYellowB("ACL Keeper")
+			}
+			if myRoles == "Gate Keeper" {
+				roleColored = utils.BgGreenB("Gate Keeper")
+			}
+
+			infoLines = append(infoLines, fmt.Sprintf("- %s (%s)", ug.User.Username, roleColored))
 		}
 	} else {
 		infoLines = append(infoLines, "Members: None")
@@ -240,18 +252,18 @@ func GroupDelete(db *gorm.DB, currentUser *models.User, args []string) error {
 
 func GroupAddMember(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("groupAddMember", flag.ContinueOnError)
-	var groupName, username, grade string
+	var groupName, username, role string
 	fs.StringVar(&groupName, "group", "", "Group name")
 	fs.StringVar(&username, "user", "", "Username to add")
-	fs.StringVar(&grade, "grade", "", "Grade (owner, aclkeeper, gatekeeper, member, guest)")
+	fs.StringVar(&role, "role", "", "Role (owner, aclkeeper, gatekeeper, member, guest)")
 	var flagOutput bytes.Buffer
 	fs.SetOutput(&flagOutput)
 
-	if err := fs.Parse(args); err != nil || strings.TrimSpace(groupName) == "" || strings.TrimSpace(username) == "" || strings.TrimSpace(grade) == "" {
+	if err := fs.Parse(args); err != nil || strings.TrimSpace(groupName) == "" || strings.TrimSpace(username) == "" || strings.TrimSpace(role) == "" {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Add Member",
 			BlockType: "error",
-			Sections:  []console.SectionContent{{SubTitle: "Usage", Body: []string{"Usage: groupAddMember --group <groupName> --user <username> --grade <grade>"}}},
+			Sections:  []console.SectionContent{{SubTitle: "Usage", Body: []string{"Usage: groupAddMember --group <groupName> --user <username> --role <role>"}}},
 		})
 		return err
 	}
@@ -295,7 +307,7 @@ func GroupAddMember(db *gorm.DB, currentUser *models.User, args []string) error 
 		return nil
 	}
 
-	newUG := models.UserGroup{UserID: u.ID, GroupID: g.ID, Role: grade}
+	newUG := models.UserGroup{UserID: u.ID, GroupID: g.ID, Role: role}
 	if err := db.Create(&newUG).Error; err != nil {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Add Member",
@@ -308,7 +320,7 @@ func GroupAddMember(db *gorm.DB, currentUser *models.User, args []string) error 
 	console.DisplayBlock(console.ContentBlock{
 		Title:     "Add Member",
 		BlockType: "success",
-		Sections:  []console.SectionContent{{SubTitle: "Success", Body: []string{fmt.Sprintf("User '%s' added to group '%s' as '%s'.", username, groupName, grade)}}},
+		Sections:  []console.SectionContent{{SubTitle: "Success", Body: []string{fmt.Sprintf("User '%s' added to group '%s' as '%s'.", username, groupName, role)}}},
 	})
 	return nil
 }

--- a/commands/system.go
+++ b/commands/system.go
@@ -94,10 +94,10 @@ func createDBUser(db *gorm.DB, username string) (*models.User, error) {
 	return &newUser, nil
 }
 
-func SwitchRoleUser(db *gorm.DB, username string) error {
+func SwitchSysRoleUser(db *gorm.DB, username string) error {
 	username = strings.ToLower(strings.TrimSpace(username))
 	if username == "" {
-		fmt.Println("Usage: switchRoleUser <username>")
+		fmt.Println("Usage: switchSysRoleUser <username>")
 		return nil
 	}
 	var checkUser models.User
@@ -112,7 +112,7 @@ func SwitchRoleUser(db *gorm.DB, username string) error {
 	}
 
 	if err := db.Save(&checkUser).Error; err != nil {
-		return fmt.Errorf("error updating user role: %w", err)
+		return fmt.Errorf("error updating user system role: %w", err)
 	}
 
 	if err := system.UpdateSudoers(&checkUser); err != nil {

--- a/main.go
+++ b/main.go
@@ -75,8 +75,8 @@ func createFirstAdminUser(db *gorm.DB) error {
 			return fmt.Errorf("error creating user: %w", err)
 		}
 
-		if err := commands.SwitchRoleUser(db, username); err != nil {
-			return fmt.Errorf("error switching role: %w", err)
+		if err := commands.SwitchSysRoleUser(db, username); err != nil {
+			return fmt.Errorf("error switching system role: %w", err)
 		}
 
 		fmt.Printf("User %s created successfully.\n", username)

--- a/utils/autocomplete/autocomplete.go
+++ b/utils/autocomplete/autocomplete.go
@@ -69,7 +69,7 @@ func Completion(d prompt.Document, user *models.User, db *gorm.DB) []prompt.Sugg
 			},
 			"accountModify": {
 				{Text: "--user", Description: "Username to modify"},
-				{Text: "--role", Description: "New role (admin or user)"},
+				{Text: "--sysrole", Description: "New system role (admin or user)"},
 			},
 			"accountDelete": {
 				{Text: "--user", Description: "Username to delete"},
@@ -125,7 +125,7 @@ func Completion(d prompt.Document, user *models.User, db *gorm.DB) []prompt.Sugg
 			"groupAddMember": {
 				{Text: "--group", Description: "Group name"},
 				{Text: "--user", Description: "Username to add"},
-				{Text: "--grade", Description: "Grade (owner, aclkeeper, gatekeeper, member, guest)"},
+				{Text: "--role", Description: "Role (owner, aclkeeper, gatekeeper, member, guest)"},
 			},
 			"groupDelMember": {
 				{Text: "--group", Description: "Group name"},

--- a/utils/grade.go
+++ b/utils/grade.go
@@ -6,25 +6,25 @@ import (
 	"goBastion/models"
 )
 
-func GetGrades(ug models.UserGroup) string {
-	var grades []string
+func GetRoles(ug models.UserGroup) string {
+	var roles []string
 	if ug.IsOwner() {
-		grades = append(grades, "Owner")
+		roles = append(roles, "Owner")
 	}
 	if ug.IsACLKeeper() {
-		grades = append(grades, "ACL Keeper")
+		roles = append(roles, "ACL Keeper")
 	}
 	if ug.IsGateKeeper() {
-		grades = append(grades, "Gate Keeper")
+		roles = append(roles, "Gate Keeper")
 	}
 	if ug.IsMember() {
-		grades = append(grades, "Member")
+		roles = append(roles, "Member")
 	}
 	if ug.IsGuest() {
-		grades = append(grades, "Guest")
+		roles = append(roles, "Guest")
 	}
-	if len(grades) == 0 {
+	if len(roles) == 0 {
 		return "None"
 	}
-	return strings.Join(grades, ", ")
+	return strings.Join(roles, ", ")
 }


### PR DESCRIPTION
* Renamed the `GetGrades` function to `GetRoles` and updated its implementation to reflect the new terminology 
* Updated all references to `GetGrades` to use the new `GetRoles` function across the codebase
* Added color-coded labels to visually distinguish roles such as "Owner," "ACL Keeper," "Gate Keeper," and "Member" in user and group information displays
* Updated the `accountModify` command to use `--sysrole` instead of `--role` for specifying system roles 
* Updated the `groupAddMember` command to use `--role` instead of `--grade` for specifying group roles 
* Adjusted error and success messages to reflect the updated terminology, such as "system role" instead of "role" 
* Renamed `SwitchRoleUser` to `SwitchSysRoleUser` for clarity and consistency with the new terminology