### PR TITLE
refactor(commands): remove Go naming stutter and Hungarian suffixes

### DIFF
--- a/internal/commands/account/add_access.go
+++ b/internal/commands/account/add_access.go
@@ -14,8 +14,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// AccountAddAccess adds a personal SSH access entry for a user.
-func AccountAddAccess(db *gorm.DB, currentUser *models.User, args []string) error {
+// AddAccess adds a personal SSH access entry for a user.
+func AddAccess(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("accountAddAccess", flag.ContinueOnError)
 	var targetUser, server, username, comment, allowedFrom, protocol string
 	var port int64

--- a/internal/commands/account/add_access_test.go
+++ b/internal/commands/account/add_access_test.go
@@ -6,12 +6,12 @@ import (
 	"goBastion/internal/models"
 )
 
-func TestAccountAddAccess_Success(t *testing.T) {
+func TestAddAccess_Success(t *testing.T) {
 	db := newTestDB(t)
 	admin := newAdminUser(t, db, "admin")
 	newRegularUser(t, db, "alice")
 
-	err := AccountAddAccess(db, admin, []string{
+	err := AddAccess(db, admin, []string{
 		"--user", "alice",
 		"--server", "1.2.3.4",
 		"--username", "root",
@@ -28,13 +28,13 @@ func TestAccountAddAccess_Success(t *testing.T) {
 	}
 }
 
-func TestAccountAddAccess_MissingServer(t *testing.T) {
+func TestAddAccess_MissingServer(t *testing.T) {
 	db := newTestDB(t)
 	admin := newAdminUser(t, db, "admin")
 	newRegularUser(t, db, "alice")
 
 	// Missing --server; should not panic, should not create DB entry
-	_ = AccountAddAccess(db, admin, []string{
+	_ = AddAccess(db, admin, []string{
 		"--user", "alice",
 		"--username", "root",
 		"--port", "22",
@@ -47,11 +47,11 @@ func TestAccountAddAccess_MissingServer(t *testing.T) {
 	}
 }
 
-func TestAccountAddAccess_UserNotFound(t *testing.T) {
+func TestAddAccess_UserNotFound(t *testing.T) {
 	db := newTestDB(t)
 	admin := newAdminUser(t, db, "admin")
 
-	err := AccountAddAccess(db, admin, []string{
+	err := AddAccess(db, admin, []string{
 		"--user", "unknown",
 		"--server", "1.2.3.4",
 		"--username", "root",

--- a/internal/commands/account/add_ingress_key.go
+++ b/internal/commands/account/add_ingress_key.go
@@ -16,20 +16,20 @@ import (
 )
 
 // CreateDBIngressKey validates and persists an SSH ingress public key for a user.
-func CreateDBIngressKey(db *gorm.DB, user *models.User, pubKeyStr string) error {
-	pubKeyStr = strings.TrimSpace(pubKeyStr)
-	if pubKeyStr == "" {
+func CreateDBIngressKey(db *gorm.DB, user *models.User, key string) error {
+	key = strings.TrimSpace(key)
+	if key == "" {
 		return fmt.Errorf("public SSH key cannot be empty")
 	}
 
-	pubKey, comment, _, _, err := ssh.ParseAuthorizedKey([]byte(pubKeyStr))
-	if err != nil || pubKey == nil {
+	pub, comment, _, _, err := ssh.ParseAuthorizedKey([]byte(key))
+	if err != nil || pub == nil {
 		return fmt.Errorf("invalid SSH key: %s", err)
 	}
 
-	sha256Fingerprint := sha256.Sum256(pubKey.Marshal())
+	sha256Fingerprint := sha256.Sum256(pub.Marshal())
 	fingerprint := base64.StdEncoding.EncodeToString(sha256Fingerprint[:])
-	keySize := sshkey.GetKeySize(pubKey)
+	keySize := sshkey.GetKeySize(pub)
 
 	var existingKey models.IngressKey
 	if err = db.Where("user_id = ? AND fingerprint = ?", user.ID, fingerprint).First(&existingKey).Error; err != nil {
@@ -42,8 +42,8 @@ func CreateDBIngressKey(db *gorm.DB, user *models.User, pubKeyStr string) error 
 
 	ingressKey := models.IngressKey{
 		UserID:      user.ID,
-		Type:        pubKey.Type(),
-		Key:         pubKeyStr,
+		Type:        pub.Type(),
+		Key:         key,
 		Fingerprint: fingerprint,
 		Size:        keySize,
 		Comment:     comment,

--- a/internal/commands/account/create.go
+++ b/internal/commands/account/create.go
@@ -19,8 +19,8 @@ import (
 	"goBastion/internal/utils/validation"
 )
 
-// AccountCreate creates a new user account with an SSH ingress key.
-func AccountCreate(db *gorm.DB, adapter osadapter.SystemAdapter, currentUser *models.User, args []string) error {
+// Create creates a new user account with an SSH ingress key.
+func Create(db *gorm.DB, adapter osadapter.SystemAdapter, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("accountCreate", flag.ContinueOnError)
 	var username string
 	var oshOnly bool
@@ -51,8 +51,8 @@ func AccountCreate(db *gorm.DB, adapter osadapter.SystemAdapter, currentUser *mo
 
 	reader := bufio.NewReader(os.Stdin)
 	fmt.Print("Enter the complete public SSH key: ")
-	pubKeyStr, err := reader.ReadString('\n')
-	if err != nil || strings.TrimSpace(pubKeyStr) == "" {
+	pubKey, err := reader.ReadString('\n')
+	if err != nil || strings.TrimSpace(pubKey) == "" {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Account Create",
 			BlockType: "error",
@@ -60,7 +60,7 @@ func AccountCreate(db *gorm.DB, adapter osadapter.SystemAdapter, currentUser *mo
 		})
 		return fmt.Errorf("invalid or missing SSH key")
 	}
-	if _, _, _, _, err = ssh.ParseAuthorizedKey([]byte(strings.TrimSpace(pubKeyStr))); err != nil {
+	if _, _, _, _, err = ssh.ParseAuthorizedKey([]byte(strings.TrimSpace(pubKey))); err != nil {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Account Create",
 			BlockType: "error",
@@ -69,7 +69,7 @@ func AccountCreate(db *gorm.DB, adapter osadapter.SystemAdapter, currentUser *mo
 		return fmt.Errorf("invalid SSH key: %v", err)
 	}
 
-	if err = CreateUser(db, adapter, username, pubKeyStr); err != nil {
+	if err = CreateUser(db, adapter, username, pubKey); err != nil {
 		title := "Error"
 		if strings.Contains(err.Error(), "exists") {
 			title = "User Exists"

--- a/internal/commands/account/create_test.go
+++ b/internal/commands/account/create_test.go
@@ -75,10 +75,10 @@ func TestCreateUser_AdapterError(t *testing.T) {
 	}
 }
 
-func TestAccountCreate_MissingArgs(t *testing.T) {
+func TestCreate_MissingArgs(t *testing.T) {
 	db := newTestDB(t)
 	mock := osadapter.NewMockAdapter()
 	admin := newAdminUser(t, db, "admin")
 	// Should not panic; missing --user arg
-	_ = AccountCreate(db, mock, admin, []string{})
+	_ = Create(db, mock, admin, []string{})
 }

--- a/internal/commands/account/del_access.go
+++ b/internal/commands/account/del_access.go
@@ -12,8 +12,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// AccountDelAccess removes a personal SSH access entry by ID.
-func AccountDelAccess(db *gorm.DB, currentUser *models.User, args []string) error {
+// DelAccess removes a personal SSH access entry by ID.
+func DelAccess(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("accountDelAccess", flag.ContinueOnError)
 	var accessID string
 	fs.StringVar(&accessID, "access", "", "Access ID to remove")

--- a/internal/commands/account/del_access_test.go
+++ b/internal/commands/account/del_access_test.go
@@ -6,7 +6,7 @@ import (
 	"goBastion/internal/models"
 )
 
-func TestAccountDelAccess_Success(t *testing.T) {
+func TestDelAccess_Success(t *testing.T) {
 	db := newTestDB(t)
 	admin := newAdminUser(t, db, "admin")
 	alice := newRegularUser(t, db, "alice")
@@ -23,7 +23,7 @@ func TestAccountDelAccess_Success(t *testing.T) {
 		t.Fatalf("create access: %v", err)
 	}
 
-	err := AccountDelAccess(db, admin, []string{"--access", access.ID.String()})
+	err := DelAccess(db, admin, []string{"--access", access.ID.String()})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -35,10 +35,10 @@ func TestAccountDelAccess_Success(t *testing.T) {
 	}
 }
 
-func TestAccountDelAccess_NotFound(t *testing.T) {
+func TestDelAccess_NotFound(t *testing.T) {
 	db := newTestDB(t)
 	admin := newAdminUser(t, db, "admin")
 
 	// Non-existent UUID — function should not return error (it silently deletes 0 rows)
-	_ = AccountDelAccess(db, admin, []string{"--access", "00000000-0000-0000-0000-000000000000"})
+	_ = DelAccess(db, admin, []string{"--access", "00000000-0000-0000-0000-000000000000"})
 }

--- a/internal/commands/account/delete.go
+++ b/internal/commands/account/delete.go
@@ -15,8 +15,8 @@ import (
 	gosync "goBastion/internal/utils/sync"
 )
 
-// AccountDelete removes a user account from the system.
-func AccountDelete(db *gorm.DB, adapter osadapter.SystemAdapter, currentUser *models.User, args []string) error {
+// Delete removes a user account from the system.
+func Delete(db *gorm.DB, adapter osadapter.SystemAdapter, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("accountDelete", flag.ContinueOnError)
 	var username string
 	fs.StringVar(&username, "user", "", "Username to delete")

--- a/internal/commands/account/disable_password.go
+++ b/internal/commands/account/disable_password.go
@@ -12,8 +12,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// AccountDisablePassword clears a user's password-based MFA (admin only).
-func AccountDisablePassword(db *gorm.DB, currentUser *models.User, log *slog.Logger, args []string) error {
+// DisablePassword clears a user's password-based MFA (admin only).
+func DisablePassword(db *gorm.DB, currentUser *models.User, log *slog.Logger, args []string) error {
 	fs := flag.NewFlagSet("accountDisablePassword", flag.ContinueOnError)
 	var targetUser string
 	var buf bytes.Buffer

--- a/internal/commands/account/disable_totp.go
+++ b/internal/commands/account/disable_totp.go
@@ -12,8 +12,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// AccountDisableTOTP lets an admin force-disable TOTP for a user (e.g. lost phone).
-func AccountDisableTOTP(db *gorm.DB, currentUser *models.User, log *slog.Logger, args []string) error {
+// DisableTOTP lets an admin force-disable TOTP for a user (e.g. lost phone).
+func DisableTOTP(db *gorm.DB, currentUser *models.User, log *slog.Logger, args []string) error {
 	fs := flag.NewFlagSet("accountDisableTOTP", flag.ContinueOnError)
 	var username string
 	fs.StringVar(&username, "user", "", "Username whose TOTP to disable")

--- a/internal/commands/account/info.go
+++ b/internal/commands/account/info.go
@@ -14,8 +14,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// AccountInfo displays detailed information for a specific user account.
-func AccountInfo(db *gorm.DB, currentUser *models.User, args []string) error {
+// Info displays detailed information for a specific user account.
+func Info(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("accountInfo", flag.ContinueOnError)
 	var username string
 	fs.StringVar(&username, "user", "", "Username to display information")

--- a/internal/commands/account/list.go
+++ b/internal/commands/account/list.go
@@ -10,8 +10,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// AccountList displays all non-system user accounts.
-func AccountList(db *gorm.DB, currentUser *models.User) error {
+// List displays all non-system user accounts.
+func List(db *gorm.DB, currentUser *models.User) error {
 	if !currentUser.CanDo(db, "accountList", "") {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Account List",

--- a/internal/commands/account/list_access.go
+++ b/internal/commands/account/list_access.go
@@ -14,8 +14,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// AccountListAccess lists all personal SSH accesses for a user.
-func AccountListAccess(db *gorm.DB, currentUser *models.User, args []string) error {
+// ListAccess lists all personal SSH accesses for a user.
+func ListAccess(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("accountListAccess", flag.ContinueOnError)
 	var username string
 	fs.StringVar(&username, "user", "", "Username to list accesses")
@@ -85,17 +85,17 @@ func AccountListAccess(db *gorm.DB, currentUser *models.User, args []string) err
 		if !access.LastConnection.IsZero() {
 			lastUsed = access.LastConnection.Format("2006-01-02 15:04:05")
 		}
-		expiresStr := "Never"
+		expires := "Never"
 		if access.ExpiresAt != nil {
 			if access.ExpiresAt.Before(time.Now()) {
-				expiresStr = "EXPIRED(" + access.ExpiresAt.Format("2006-01-02") + ")"
+				expires = "EXPIRED(" + access.ExpiresAt.Format("2006-01-02") + ")"
 			} else {
-				expiresStr = access.ExpiresAt.Format("2006-01-02")
+				expires = access.ExpiresAt.Format("2006-01-02")
 			}
 		}
-		fromStr := access.AllowedFrom
-		if fromStr == "" {
-			fromStr = "*"
+		allowedFrom := access.AllowedFrom
+		if allowedFrom == "" {
+			allowedFrom = "*"
 		}
 		proto := access.Protocol
 		if proto == "" {
@@ -108,8 +108,8 @@ func AccountListAccess(db *gorm.DB, currentUser *models.User, args []string) err
 			access.Port,
 			proto,
 			access.Comment,
-			fromStr,
-			expiresStr,
+			allowedFrom,
+			expires,
 			lastUsed,
 			access.CreatedAt.Format("2006-01-02 15:04:05"),
 		)

--- a/internal/commands/account/list_egress_keys.go
+++ b/internal/commands/account/list_egress_keys.go
@@ -12,8 +12,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// AccountListEgressKeys lists all egress SSH keys for a user.
-func AccountListEgressKeys(db *gorm.DB, currentUser *models.User, args []string) error {
+// ListEgressKeys lists all egress SSH keys for a user.
+func ListEgressKeys(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("accountListEgressKeys", flag.ContinueOnError)
 	var username string
 	fs.StringVar(&username, "user", "", "Username to list egress keys")

--- a/internal/commands/account/list_ingress_keys.go
+++ b/internal/commands/account/list_ingress_keys.go
@@ -12,8 +12,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// AccountListIngressKeys lists all ingress SSH keys for a user.
-func AccountListIngressKeys(db *gorm.DB, currentUser *models.User, args []string) error {
+// ListIngressKeys lists all ingress SSH keys for a user.
+func ListIngressKeys(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("accountListIngressKeys", flag.ContinueOnError)
 	var username string
 	fs.StringVar(&username, "user", "", "Username to list ingress keys")

--- a/internal/commands/account/modify.go
+++ b/internal/commands/account/modify.go
@@ -14,8 +14,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// AccountModify updates the system role of a user account.
-func AccountModify(db *gorm.DB, currentUser *models.User, args []string) error {
+// Modify updates the system role of a user account.
+func Modify(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("accountModify", flag.ContinueOnError)
 	var username, newRole, oshOnlyRaw, superOwnerRaw string
 	fs.StringVar(&username, "user", "", "Username to modify")

--- a/internal/commands/account/set_password.go
+++ b/internal/commands/account/set_password.go
@@ -15,8 +15,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// AccountSetPassword sets or clears a password MFA second factor for a user account (admin only).
-func AccountSetPassword(db *gorm.DB, currentUser *models.User, log *slog.Logger, args []string) error {
+// SetPassword sets or clears a password MFA second factor for a user account (admin only).
+func SetPassword(db *gorm.DB, currentUser *models.User, log *slog.Logger, args []string) error {
 	fs := flag.NewFlagSet("accountSetPassword", flag.ContinueOnError)
 	var targetUser string
 	var clear bool
@@ -71,15 +71,15 @@ func AccountSetPassword(db *gorm.DB, currentUser *models.User, log *slog.Logger,
 	if err != nil {
 		return fmt.Errorf("could not read password: %v", err)
 	}
-	passStr := string(passBytes)
-	if len(passStr) < 8 {
+	password := string(passBytes)
+	if len(password) < 8 {
 		console.DisplayBlock(console.ContentBlock{
 			Title: "Set Account Password MFA", BlockType: "error",
 			Sections: []console.SectionContent{{SubTitle: "Error", Body: []string{"Password must be at least 8 characters."}}},
 		})
 		return nil
 	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(passStr), bcrypt.DefaultCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return fmt.Errorf("bcrypt error: %v", err)
 	}

--- a/internal/commands/cmdhelper/helpers.go
+++ b/internal/commands/cmdhelper/helpers.go
@@ -1,0 +1,173 @@
+package cmdhelper
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"goBastion/internal/models"
+	"goBastion/internal/utils/console"
+	"goBastion/internal/utils/validation"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type StringFlag struct {
+	Ptr   *string
+	Name  string
+	Def   string
+	Usage string
+}
+
+type BoolFlag struct {
+	Ptr   *bool
+	Name  string
+	Def   bool
+	Usage string
+}
+
+type IntFlag struct {
+	Ptr   *int
+	Name  string
+	Def   int
+	Usage string
+}
+
+type Int64Flag struct {
+	Ptr   *int64
+	Name  string
+	Def   int64
+	Usage string
+}
+
+func ParseFlags(cmdName, usage string, args []string, flags ...interface{}) (*flag.FlagSet, error) {
+	fs := flag.NewFlagSet(cmdName, flag.ContinueOnError)
+	for _, f := range flags {
+		switch v := f.(type) {
+		case StringFlag:
+			fs.StringVar(v.Ptr, v.Name, v.Def, v.Usage)
+		case BoolFlag:
+			fs.BoolVar(v.Ptr, v.Name, v.Def, v.Usage)
+		case IntFlag:
+			fs.IntVar(v.Ptr, v.Name, v.Def, v.Usage)
+		case Int64Flag:
+			fs.Int64Var(v.Ptr, v.Name, v.Def, v.Usage)
+		}
+	}
+	return fs, fs.Parse(args)
+}
+
+func CleanArgs(ptrs ...*string) {
+	for _, p := range ptrs {
+		*p = strings.TrimSpace(*p)
+	}
+}
+
+func RequirePermission(db *gorm.DB, user *models.User, permission, resource, title string) error {
+	if !user.CanDo(db, permission, resource) {
+		console.ErrorBlock(title, "Access Denied", fmt.Sprintf("You do not have permission to perform this action on '%s'.", resource))
+		return fmt.Errorf("access denied for %s", user.Username)
+	}
+	return nil
+}
+
+func FindGroup(db *gorm.DB, name, title string) (*models.Group, error) {
+	var g models.Group
+	if err := db.Where("name = ?", name).First(&g).Error; err != nil {
+		console.ErrorBlock(title, "Not Found", fmt.Sprintf("Group '%s' not found.", name))
+		return nil, err
+	}
+	return &g, nil
+}
+
+func FindUser(db *gorm.DB, username, title string) (*models.User, error) {
+	var u models.User
+	if err := db.Where("username = ?", username).First(&u).Error; err != nil {
+		console.ErrorBlock(title, "Not Found", fmt.Sprintf("User '%s' not found.", username))
+		return nil, err
+	}
+	return &u, nil
+}
+
+func FindRealm(db *gorm.DB, name, title string) (*models.Realm, error) {
+	var r models.Realm
+	if err := db.Where("name = ?", name).First(&r).Error; err != nil {
+		console.ErrorBlock(title, "Not Found", fmt.Sprintf("Realm '%s' not found.", name))
+		return nil, err
+	}
+	return &r, nil
+}
+
+func EnsureNotLastAdmin(db *gorm.DB, title string) error {
+	var count int64
+	if err := db.Model(&models.User{}).Where("role = ? AND deleted_at IS NULL", models.RoleAdmin).Count(&count).Error; err != nil {
+		return fmt.Errorf("error counting admins: %w", err)
+	}
+	if count <= 1 {
+		console.ErrorBlock(title, "Operation Denied", "Cannot demote or remove the last remaining admin.")
+		return fmt.Errorf("cannot demote the last remaining admin")
+	}
+	return nil
+}
+
+func ValidateHost(host, title string) bool {
+	if !validation.IsValidHost(host) {
+		console.ErrorBlock(title, "Invalid Server", "Server hostname/IP contains invalid characters (e.g., '@').")
+		return false
+	}
+	return true
+}
+
+func ValidateUsername(username, title string) bool {
+	if !validation.IsValidUsername(username) {
+		console.ErrorBlock(title, "Invalid Username", "SSH username contains invalid characters.")
+		return false
+	}
+	return true
+}
+
+func ValidatePort(port int64, title string) bool {
+	if !validation.IsValidPort(port) {
+		console.ErrorBlock(title, "Invalid Port", "Port must be between 1 and 65535.")
+		return false
+	}
+	return true
+}
+
+func ValidateProtocol(protocol, title string) bool {
+	if !validation.IsValidProtocol(protocol) {
+		console.ErrorBlock(title, "Invalid Protocol", "Protocol must be one of: ssh, scpupload, scpdownload, sftp, rsync.")
+		return false
+	}
+	return true
+}
+
+func ValidateCIDRs(cidrs, title string) bool {
+	if !validation.IsValidCIDRs(cidrs) {
+		console.ErrorBlock(title, "Invalid CIDRs", "--from must be a comma-separated list of valid CIDR notation (e.g. 10.0.0.0/8,192.168.1.0/24).")
+		return false
+	}
+	return true
+}
+
+func ReadInput(prompt string) (string, error) {
+	fmt.Print(prompt)
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(input), nil
+}
+
+func ParseUUID(id, title string) (uuid.UUID, error) {
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		console.ErrorBlock(title, "Invalid UUID", fmt.Sprintf("'%s' is not a valid UUID.", id))
+		return uuid.Nil, err
+	}
+	return parsed, nil
+}

--- a/internal/commands/group/add_access.go
+++ b/internal/commands/group/add_access.go
@@ -16,8 +16,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// GroupAddAccess adds an SSH access entry to a group.
-func GroupAddAccess(db *gorm.DB, currentUser *models.User, args []string) error {
+// AddAccess adds an SSH access entry to a group.
+func AddAccess(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("groupAddAccess", flag.ContinueOnError)
 	var groupName, server, username, comment, allowedFrom, protocol string
 	var port int64

--- a/internal/commands/group/add_access_test.go
+++ b/internal/commands/group/add_access_test.go
@@ -6,7 +6,7 @@ import (
 	"goBastion/internal/models"
 )
 
-func TestGroupAddAccess_Success(t *testing.T) {
+func TestAddAccess_Success(t *testing.T) {
 	db := newTestDB(t)
 	admin := newAdminUser(t, db, "admin")
 
@@ -15,7 +15,7 @@ func TestGroupAddAccess_Success(t *testing.T) {
 		t.Fatalf("create group: %v", err)
 	}
 
-	err := GroupAddAccess(db, admin, []string{
+	err := AddAccess(db, admin, []string{
 		"--group", "mygroup",
 		"--server", "10.0.0.1",
 		"--username", "deploy",

--- a/internal/commands/group/add_alias.go
+++ b/internal/commands/group/add_alias.go
@@ -13,8 +13,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// GroupAddAlias creates an alias for a group access target.
-func GroupAddAlias(db *gorm.DB, currentUser *models.User, args []string) error {
+// AddAlias creates an alias for a group access target.
+func AddAlias(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("groupAddAlias", flag.ContinueOnError)
 	var groupName, alias, hostname string
 	fs.StringVar(&groupName, "group", "", "Group name")

--- a/internal/commands/group/add_member.go
+++ b/internal/commands/group/add_member.go
@@ -12,8 +12,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// GroupAddMember adds a user to a group with a specified role.
-func GroupAddMember(db *gorm.DB, currentUser *models.User, args []string) error {
+// AddMember adds a user to a group with a specified role.
+func AddMember(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("groupAddMember", flag.ContinueOnError)
 	var groupName, username, role string
 	fs.StringVar(&groupName, "group", "", "Group name")

--- a/internal/commands/group/add_member_test.go
+++ b/internal/commands/group/add_member_test.go
@@ -6,7 +6,7 @@ import (
 	"goBastion/internal/models"
 )
 
-func TestGroupAddMember_Success(t *testing.T) {
+func TestAddMember_Success(t *testing.T) {
 	db := newTestDB(t)
 	admin := newAdminUser(t, db, "admin")
 	newRegularUser(t, db, "alice")
@@ -16,7 +16,7 @@ func TestGroupAddMember_Success(t *testing.T) {
 		t.Fatalf("create group: %v", err)
 	}
 
-	err := GroupAddMember(db, admin, []string{
+	err := AddMember(db, admin, []string{
 		"--group", "mygroup",
 		"--user", "alice",
 		"--role", "member",
@@ -34,7 +34,7 @@ func TestGroupAddMember_Success(t *testing.T) {
 	}
 }
 
-func TestGroupAddMember_InvalidRole(t *testing.T) {
+func TestAddMember_InvalidRole(t *testing.T) {
 	db := newTestDB(t)
 	admin := newAdminUser(t, db, "admin")
 	newRegularUser(t, db, "alice")
@@ -46,7 +46,7 @@ func TestGroupAddMember_InvalidRole(t *testing.T) {
 
 	// The function accepts any non-empty role string; "invalidrole" creates the row
 	// but we verify it does not panic.
-	_ = GroupAddMember(db, admin, []string{
+	_ = AddMember(db, admin, []string{
 		"--group", "mygroup",
 		"--user", "alice",
 		"--role", "invalidrole",

--- a/internal/commands/group/create.go
+++ b/internal/commands/group/create.go
@@ -15,8 +15,8 @@ import (
 
 var groupNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
-// GroupCreate creates a new group.
-func GroupCreate(db *gorm.DB, currentUser *models.User, args []string) error {
+// Create creates a new group.
+func Create(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("groupCreate", flag.ContinueOnError)
 	var groupName string
 	fs.StringVar(&groupName, "group", "", "Group name")

--- a/internal/commands/group/create_test.go
+++ b/internal/commands/group/create_test.go
@@ -6,11 +6,11 @@ import (
 	"goBastion/internal/models"
 )
 
-func TestGroupCreate_Success(t *testing.T) {
+func TestCreate_Success(t *testing.T) {
 	db := newTestDB(t)
 	admin := newAdminUser(t, db, "admin")
 
-	err := GroupCreate(db, admin, []string{"--group", "mygroup"})
+	err := Create(db, admin, []string{"--group", "mygroup"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -21,15 +21,15 @@ func TestGroupCreate_Success(t *testing.T) {
 	}
 }
 
-func TestGroupCreate_Duplicate(t *testing.T) {
+func TestCreate_Duplicate(t *testing.T) {
 	db := newTestDB(t)
 	admin := newAdminUser(t, db, "admin")
 
-	if err := GroupCreate(db, admin, []string{"--group", "mygroup"}); err != nil {
+	if err := Create(db, admin, []string{"--group", "mygroup"}); err != nil {
 		t.Fatalf("unexpected error on first create: %v", err)
 	}
 	// Second create returns nil (group already exists, no error, no duplicate)
-	_ = GroupCreate(db, admin, []string{"--group", "mygroup"})
+	_ = Create(db, admin, []string{"--group", "mygroup"})
 
 	var count int64
 	db.Model(&models.Group{}).Where("name = ?", "mygroup").Count(&count)
@@ -38,11 +38,11 @@ func TestGroupCreate_Duplicate(t *testing.T) {
 	}
 }
 
-func TestGroupCreate_AccessDenied(t *testing.T) {
+func TestCreate_AccessDenied(t *testing.T) {
 	db := newTestDB(t)
 	regular := newRegularUser(t, db, "regularuser")
 
-	err := GroupCreate(db, regular, []string{"--group", "mygroup"})
+	err := Create(db, regular, []string{"--group", "mygroup"})
 	if err == nil {
 		t.Fatal("expected access denied error for regular user, got nil")
 	}

--- a/internal/commands/group/del_access.go
+++ b/internal/commands/group/del_access.go
@@ -12,8 +12,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// GroupDelAccess removes an SSH access entry from a group.
-func GroupDelAccess(db *gorm.DB, currentUser *models.User, args []string) error {
+// DelAccess removes an SSH access entry from a group.
+func DelAccess(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("groupDelAccess", flag.ContinueOnError)
 	var groupName, accessIDStr string
 	fs.StringVar(&groupName, "group", "", "Group name")

--- a/internal/commands/group/del_access_test.go
+++ b/internal/commands/group/del_access_test.go
@@ -6,7 +6,7 @@ import (
 	"goBastion/internal/models"
 )
 
-func TestGroupDelAccess_Success(t *testing.T) {
+func TestDelAccess_Success(t *testing.T) {
 	db := newTestDB(t)
 	admin := newAdminUser(t, db, "admin")
 
@@ -16,7 +16,7 @@ func TestGroupDelAccess_Success(t *testing.T) {
 	}
 
 	access := models.GroupAccess{
-		GroupID:  g.ID,
+		GroupID: g.ID,
 		Server:   "10.0.0.1",
 		Port:     22,
 		Username: "deploy",
@@ -26,7 +26,7 @@ func TestGroupDelAccess_Success(t *testing.T) {
 		t.Fatalf("create group access: %v", err)
 	}
 
-	err := GroupDelAccess(db, admin, []string{
+	err := DelAccess(db, admin, []string{
 		"--group", "mygroup",
 		"--access", access.ID.String(),
 	})

--- a/internal/commands/group/del_alias.go
+++ b/internal/commands/group/del_alias.go
@@ -13,8 +13,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// GroupDelAlias removes an alias from a group.
-func GroupDelAlias(db *gorm.DB, currentUser *models.User, args []string) error {
+// DelAlias removes an alias from a group.
+func DelAlias(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("groupDelAlias", flag.ContinueOnError)
 	var groupName, hostID string
 	fs.StringVar(&groupName, "group", "", "Group name")

--- a/internal/commands/group/del_member.go
+++ b/internal/commands/group/del_member.go
@@ -12,8 +12,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// GroupDelMember removes a user from a group.
-func GroupDelMember(db *gorm.DB, currentUser *models.User, args []string) error {
+// DelMember removes a user from a group.
+func DelMember(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("groupDelMember", flag.ContinueOnError)
 	var groupName, username string
 	fs.StringVar(&groupName, "group", "", "Group name")

--- a/internal/commands/group/del_member_test.go
+++ b/internal/commands/group/del_member_test.go
@@ -6,7 +6,7 @@ import (
 	"goBastion/internal/models"
 )
 
-func TestGroupDelMember_Success(t *testing.T) {
+func TestDelMember_Success(t *testing.T) {
 	db := newTestDB(t)
 	admin := newAdminUser(t, db, "admin")
 	alice := newRegularUser(t, db, "alice")
@@ -21,7 +21,7 @@ func TestGroupDelMember_Success(t *testing.T) {
 		t.Fatalf("create user group: %v", err)
 	}
 
-	err := GroupDelMember(db, admin, []string{
+	err := DelMember(db, admin, []string{
 		"--group", "mygroup",
 		"--user", "alice",
 	})

--- a/internal/commands/group/delete.go
+++ b/internal/commands/group/delete.go
@@ -12,8 +12,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// GroupDelete removes a group and its associated data.
-func GroupDelete(db *gorm.DB, currentUser *models.User, args []string) error {
+// Delete removes a group and its associated data.
+func Delete(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("groupDelete", flag.ContinueOnError)
 	var groupName string
 	fs.StringVar(&groupName, "group", "", "Group name")

--- a/internal/commands/group/delete_test.go
+++ b/internal/commands/group/delete_test.go
@@ -6,7 +6,7 @@ import (
 	"goBastion/internal/models"
 )
 
-func TestGroupDelete_Success(t *testing.T) {
+func TestDelete_Success(t *testing.T) {
 	db := newTestDB(t)
 	admin := newAdminUser(t, db, "admin")
 
@@ -16,7 +16,7 @@ func TestGroupDelete_Success(t *testing.T) {
 		t.Fatalf("create group: %v", err)
 	}
 
-	err := GroupDelete(db, admin, []string{"--group", "todelete"})
+	err := Delete(db, admin, []string{"--group", "todelete"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -28,10 +28,10 @@ func TestGroupDelete_Success(t *testing.T) {
 	}
 }
 
-func TestGroupDelete_NotFound(t *testing.T) {
+func TestDelete_NotFound(t *testing.T) {
 	db := newTestDB(t)
 	admin := newAdminUser(t, db, "admin")
 
 	// Deleting non-existent group should not return error (GORM soft-delete on 0 rows)
-	_ = GroupDelete(db, admin, []string{"--group", "nonexistent"})
+	_ = Delete(db, admin, []string{"--group", "nonexistent"})
 }

--- a/internal/commands/group/generate_egress_key.go
+++ b/internal/commands/group/generate_egress_key.go
@@ -22,8 +22,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// GroupGenerateEgressKey generates a new SSH egress key pair for a group.
-func GroupGenerateEgressKey(db *gorm.DB, currentUser *models.User, args []string) error {
+// GenerateEgressKey generates a new SSH egress key pair for a group.
+func GenerateEgressKey(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("groupGenerateEgressKey", flag.ContinueOnError)
 	var groupName, keyType string
 	var keySize int

--- a/internal/commands/group/info.go
+++ b/internal/commands/group/info.go
@@ -13,8 +13,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// GroupInfo displays detailed information about a group.
-func GroupInfo(db *gorm.DB, currentUser *models.User, args []string) error {
+// Info displays detailed information about a group.
+func Info(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("groupInfo", flag.ContinueOnError)
 	var groupName string
 	fs.StringVar(&groupName, "group", "", "Group name")

--- a/internal/commands/group/list.go
+++ b/internal/commands/group/list.go
@@ -13,8 +13,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// GroupList displays all groups, optionally filtered by membership.
-func GroupList(db *gorm.DB, user *models.User, args []string) error {
+// List displays all groups, optionally filtered by membership.
+func List(db *gorm.DB, user *models.User, args []string) error {
 	fs := flag.NewFlagSet("groupList", flag.ContinueOnError)
 	all := fs.Bool("all", false, "List all groups")
 	var flagOutput bytes.Buffer

--- a/internal/commands/group/list_accesses.go
+++ b/internal/commands/group/list_accesses.go
@@ -14,8 +14,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// GroupListAccesses lists all SSH accesses for a group.
-func GroupListAccesses(db *gorm.DB, currentUser *models.User, args []string) error {
+// ListAccesses lists all SSH accesses for a group.
+func ListAccesses(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("groupListAccesses", flag.ContinueOnError)
 	var groupName string
 	fs.StringVar(&groupName, "group", "", "Group name")
@@ -77,17 +77,17 @@ func GroupListAccesses(db *gorm.DB, currentUser *models.User, args []string) err
 		if !access.LastConnection.IsZero() {
 			lastUsed = access.LastConnection.Format("2006-01-02 15:04:05")
 		}
-		expiresStr := "Never"
+		expires := "Never"
 		if access.ExpiresAt != nil {
 			if access.ExpiresAt.Before(time.Now()) {
-				expiresStr = "EXPIRED(" + access.ExpiresAt.Format("2006-01-02") + ")"
+				expires = "EXPIRED(" + access.ExpiresAt.Format("2006-01-02") + ")"
 			} else {
-				expiresStr = access.ExpiresAt.Format("2006-01-02")
+				expires = access.ExpiresAt.Format("2006-01-02")
 			}
 		}
-		fromStr := access.AllowedFrom
-		if fromStr == "" {
-			fromStr = "*"
+		allowedFrom := access.AllowedFrom
+		if allowedFrom == "" {
+			allowedFrom = "*"
 		}
 		proto := access.Protocol
 		if proto == "" {
@@ -105,8 +105,8 @@ func GroupListAccesses(db *gorm.DB, currentUser *models.User, args []string) err
 			proto,
 			guestScope,
 			access.Comment,
-			fromStr,
-			expiresStr,
+			allowedFrom,
+			expires,
 			lastUsed,
 			access.CreatedAt.Format("2006-01-02 15:04:05"),
 		)

--- a/internal/commands/group/list_aliases.go
+++ b/internal/commands/group/list_aliases.go
@@ -13,8 +13,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// GroupListAliases lists all aliases for a group.
-func GroupListAliases(db *gorm.DB, currentUser *models.User, args []string) error {
+// ListAliases lists all aliases for a group.
+func ListAliases(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("groupListAliases", flag.ContinueOnError)
 	var groupName string
 	fs.StringVar(&groupName, "group", "", "Group name")

--- a/internal/commands/group/list_egress_keys.go
+++ b/internal/commands/group/list_egress_keys.go
@@ -12,8 +12,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// GroupListEgressKeys lists all egress SSH keys for a group.
-func GroupListEgressKeys(db *gorm.DB, currentUser *models.User, args []string) error {
+// ListEgressKeys lists all egress SSH keys for a group.
+func ListEgressKeys(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("groupListEgressKeys", flag.ContinueOnError)
 	var groupName string
 	fs.StringVar(&groupName, "group", "", "Group name")

--- a/internal/commands/group/set_mfa.go
+++ b/internal/commands/group/set_mfa.go
@@ -12,9 +12,9 @@ import (
 	"gorm.io/gorm"
 )
 
-// GroupSetMFA enables or disables JIT MFA requirement for a group.
+// SetMFA enables or disables JIT MFA requirement for a group.
 // When enabled, users connecting via this group must pass a TOTP challenge even if TOTP is not globally enabled.
-func GroupSetMFA(db *gorm.DB, currentUser *models.User, log *slog.Logger, args []string) error {
+func SetMFA(db *gorm.DB, currentUser *models.User, log *slog.Logger, args []string) error {
 	fs := flag.NewFlagSet("groupSetMFA", flag.ContinueOnError)
 	var groupName string
 	var required, optional bool

--- a/internal/commands/piv/add_trust_anchor.go
+++ b/internal/commands/piv/add_trust_anchor.go
@@ -12,9 +12,9 @@ import (
 	"gorm.io/gorm"
 )
 
-// PivAddTrustAnchor adds a PIV CA trust anchor (admin only).
+// AddTrustAnchor adds a PIV CA trust anchor (admin only).
 // Usage: pivAddTrustAnchor --name <name> --cert <path>
-func PivAddTrustAnchor(db *gorm.DB, currentUser *models.User, args []string) error {
+func AddTrustAnchor(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("pivAddTrustAnchor", flag.ContinueOnError)
 	var name, certFile string
 	fs.StringVar(&name, "name", "", "Friendly name for this trust anchor")

--- a/internal/commands/piv/list_trust_anchors.go
+++ b/internal/commands/piv/list_trust_anchors.go
@@ -12,8 +12,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// PivListTrustAnchors lists all registered PIV trust anchors (admin only).
-func PivListTrustAnchors(db *gorm.DB, currentUser *models.User, args []string) error {
+// ListTrustAnchors lists all registered PIV trust anchors (admin only).
+func ListTrustAnchors(db *gorm.DB, currentUser *models.User, args []string) error {
 	var anchors []models.PIVTrustAnchor
 	if err := db.Preload("AddedBy").Find(&anchors).Error; err != nil {
 		console.DisplayBlock(console.ContentBlock{

--- a/internal/commands/piv/remove_trust_anchor.go
+++ b/internal/commands/piv/remove_trust_anchor.go
@@ -11,9 +11,9 @@ import (
 	"gorm.io/gorm"
 )
 
-// PivRemoveTrustAnchor removes a PIV trust anchor by name (admin only).
+// RemoveTrustAnchor removes a PIV trust anchor by name (admin only).
 // Usage: pivRemoveTrustAnchor --name <name>
-func PivRemoveTrustAnchor(db *gorm.DB, currentUser *models.User, args []string) error {
+func RemoveTrustAnchor(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("pivRemoveTrustAnchor", flag.ContinueOnError)
 	var name string
 	fs.StringVar(&name, "name", "", "Name of the trust anchor to remove")

--- a/internal/commands/realm/create.go
+++ b/internal/commands/realm/create.go
@@ -16,8 +16,8 @@ import (
 
 var realmNameRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
 
-// RealmCreate registers a trusted external bastion realm.
-func RealmCreate(db *gorm.DB, currentUser *models.User, args []string) error {
+// Create registers a trusted external bastion realm.
+func Create(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("realmCreate", flag.ContinueOnError)
 	var realmName, bastionHost, allowedFrom, publicKey string
 	var bastionPort int64

--- a/internal/commands/realm/delete.go
+++ b/internal/commands/realm/delete.go
@@ -12,8 +12,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// RealmDelete removes a realm configuration.
-func RealmDelete(db *gorm.DB, currentUser *models.User, args []string) error {
+// Delete removes a realm configuration.
+func Delete(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("realmDelete", flag.ContinueOnError)
 	var realmName string
 	fs.StringVar(&realmName, "realm", "", "Realm name")

--- a/internal/commands/realm/info.go
+++ b/internal/commands/realm/info.go
@@ -12,8 +12,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// RealmInfo prints details for one realm.
-func RealmInfo(db *gorm.DB, currentUser *models.User, args []string) error {
+// Info prints details for one realm.
+func Info(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("realmInfo", flag.ContinueOnError)
 	var realmName string
 	fs.StringVar(&realmName, "realm", "", "Realm name")

--- a/internal/commands/realm/list.go
+++ b/internal/commands/realm/list.go
@@ -12,8 +12,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// RealmList lists configured realms.
-func RealmList(db *gorm.DB, currentUser *models.User, args []string) error {
+// List lists configured realms.
+func List(db *gorm.DB, currentUser *models.User, args []string) error {
 	var realms []models.Realm
 	if err := db.Preload("CreatedBy").Order("name asc").Find(&realms).Error; err != nil {
 		console.DisplayBlock(console.ContentBlock{

--- a/internal/commands/registry/registry.go
+++ b/internal/commands/registry/registry.go
@@ -45,51 +45,51 @@ func BuildRegistry(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 		{
 			Name: "selfListIngressKeys", Description: "List your ingress keys", Permission: "selfListIngressKeys",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "Ingress (you → bastion)",
-			Handler: func() error { return cmdself.SelfListIngressKeys(db, user) },
+			Handler: func() error { return cmdself.ListIngressKeys(db, user) },
 		},
 		{
 			Name: "selfAddIngressKey", Description: "Add a new ingress key", Permission: "selfAddIngressKey",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "Ingress (you → bastion)",
 			Args:    []ArgSpec{{"--key", "SSH public key"}, {"--expires", "Key expiry in days"}},
-			Handler: func() error { return cmdself.SelfAddIngressKey(db, user, args) },
+			Handler: func() error { return cmdself.AddIngressKey(db, user, args) },
 		},
 		{
 			Name: "selfDelIngressKey", Description: "Delete an ingress key", Permission: "selfDelIngressKey",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "Ingress (you → bastion)",
 			Args:    []ArgSpec{{"--id", "SSH public key ID"}},
-			Handler: func() error { return cmdself.SelfDelIngressKey(db, user, args) },
+			Handler: func() error { return cmdself.DelIngressKey(db, user, args) },
 		},
 
 		// --- Self: Egress ---
 		{
 			Name: "selfListEgressKeys", Description: "List your egress keys", Permission: "selfListEgressKeys",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "Egress (bastion → server)",
-			Handler: func() error { return cmdself.SelfListEgressKeys(db, user) },
+			Handler: func() error { return cmdself.ListEgressKeys(db, user) },
 		},
 		{
 			Name: "selfGenerateEgressKey", Description: "Generate a new egress key", Permission: "selfGenerateEgressKey",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "Egress (bastion → server)",
 			Args:    []ArgSpec{{"--type", "Key type (e.g., rsa, ed25519)"}, {"--size", "Key size"}},
-			Handler: func() error { return cmdself.SelfGenerateEgressKey(db, user, args) },
+			Handler: func() error { return cmdself.GenerateEgressKey(db, user, args) },
 		},
 		{
 			Name: "selfRemoveHostFromKnownHosts", Description: "Remove a host from known hosts", Permission: "selfRemoveHostFromKnownHosts",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "Egress (bastion → server)",
 			Args:    []ArgSpec{{"--host", "Host to remove from known_hosts"}},
-			Handler: func() error { return cmdself.SelfRemoveHostFromKnownHosts(db, user, args) },
+			Handler: func() error { return cmdself.RemoveHostFromKnownHosts(db, user, args) },
 		},
 		{
 			Name: "selfReplaceKnownHost", Description: "Trust new host key (after key change)", Permission: "selfReplaceKnownHost",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "Egress (bastion → server)",
 			Args:    []ArgSpec{{"--host", "Host whose key changed"}},
-			Handler: func() error { return cmdself.SelfReplaceKnownHost(db, user, args) },
+			Handler: func() error { return cmdself.ReplaceKnownHost(db, user, args) },
 		},
 
 		// --- Self: Accesses ---
 		{
 			Name: "selfListAccesses", Description: "List your personal accesses", Permission: "selfListAccesses",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "Server accesses (personal)",
-			Handler: func() error { return cmdself.SelfListAccesses(db, user) },
+			Handler: func() error { return cmdself.ListAccesses(db, user) },
 		},
 		{
 			Name: "selfAddAccess", Description: "Add a personal access", Permission: "selfAddAccess",
@@ -99,59 +99,59 @@ func BuildRegistry(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 				{"--comment", "Comment"}, {"--from", "Allowed source CIDRs (comma-separated)"},
 				{"--ttl", "Access expiry in days"}, {"--protocol", "Protocol restriction: ssh, scpupload, scpdownload, sftp, rsync"},
 			},
-			Handler: func() error { return cmdself.SelfAddAccess(db, user, args) },
+			Handler: func() error { return cmdself.AddAccess(db, user, args) },
 		},
 		{
 			Name: "selfDelAccess", Description: "Delete a personal access", Permission: "selfDelAccess",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "Server accesses (personal)",
 			Args:    []ArgSpec{{"--id", "Access ID"}},
-			Handler: func() error { return cmdself.SelfDelAccess(db, user, args) },
+			Handler: func() error { return cmdself.DelAccess(db, user, args) },
 		},
 
 		// --- Self: Aliases ---
 		{
 			Name: "selfListAliases", Description: "List your personal aliases", Permission: "selfListAliases",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "Server alias (personal)",
-			Handler: func() error { return cmdself.SelfListAliases(db, user) },
+			Handler: func() error { return cmdself.ListAliases(db, user) },
 		},
 		{
 			Name: "selfAddAlias", Description: "Add a personal alias", Permission: "selfAddAlias",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "Server alias (personal)",
 			Args:    []ArgSpec{{"--alias", "Alias"}, {"--hostname", "Host name"}},
-			Handler: func() error { return cmdself.SelfAddAlias(db, user, args) },
+			Handler: func() error { return cmdself.AddAlias(db, user, args) },
 		},
 		{
 			Name: "selfDelAlias", Description: "Delete a personal alias", Permission: "selfDelAlias",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "Server alias (personal)",
 			Args:    []ArgSpec{{"--id", "Alias ID"}},
-			Handler: func() error { return cmdself.SelfDelAlias(db, user, args) },
+			Handler: func() error { return cmdself.DelAlias(db, user, args) },
 		},
 
 		// --- Self: MFA / TOTP / PIV ---
 		{
 			Name: "selfSetupTOTP", Description: "Enable TOTP two-factor authentication", Permission: "selfSetupTOTP",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "MFA / TOTP / PIV",
-			Handler: func() error { return cmdtotp.SelfSetupTOTP(db, user, log) },
+			Handler: func() error { return cmdtotp.SetupTOTP(db, user, log) },
 		},
 		{
 			Name: "selfDisableTOTP", Description: "Disable TOTP two-factor authentication", Permission: "selfDisableTOTP",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "MFA / TOTP / PIV",
-			Handler: func() error { return cmdtotp.SelfDisableTOTP(db, user, log) },
+			Handler: func() error { return cmdtotp.DisableTOTP(db, user, log) },
 		},
 		{
 			Name: "selfSetPassword", Description: "Set a password second factor (MFA)", Permission: "selfSetPassword",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "MFA / TOTP / PIV",
-			Handler: func() error { return cmdself.SelfSetPassword(db, user, log, args) },
+			Handler: func() error { return cmdself.SetPassword(db, user, log, args) },
 		},
 		{
 			Name: "selfChangePassword", Description: "Change your password second factor", Permission: "selfChangePassword",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "MFA / TOTP / PIV",
-			Handler: func() error { return cmdself.SelfChangePassword(db, user, log, args) },
+			Handler: func() error { return cmdself.ChangePassword(db, user, log, args) },
 		},
 		{
 			Name: "selfDisablePassword", Description: "Disable password second factor (MFA)", Permission: "selfDisablePassword",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "MFA / TOTP / PIV",
-			Handler: func() error { return cmdself.SelfDisablePassword(db, user, log, args) },
+			Handler: func() error { return cmdself.DisablePassword(db, user, log, args) },
 		},
 		{
 			Name: "selfAddIngressKeyPIV", Description: "Add a PIV/hardware-attested SSH key (YubiKey)", Permission: "selfAddIngressKeyPIV",
@@ -161,36 +161,36 @@ func BuildRegistry(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 				{"--intermediate", "Path to intermediate certificate (PEM)"},
 				{"--comment", "Comment for this key"},
 			},
-			Handler: func() error { return cmdself.SelfAddIngressKeyPIV(db, user, args) },
+			Handler: func() error { return cmdself.AddIngressKeyPIV(db, user, args) },
 		},
 		{
 			Name: "selfGenerateBackupCodes", Description: "Generate TOTP backup codes", Permission: "selfSetupTOTP",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "MFA / TOTP / PIV",
-			Handler: func() error { return cmdself.SelfGenerateBackupCodes(db, user, log) },
+			Handler: func() error { return cmdself.GenerateBackupCodes(db, user, log) },
 		},
 		{
 			Name: "selfShowBackupCodeCount", Description: "Show remaining backup codes count", Permission: "selfSetupTOTP",
 			Category: "MANAGE YOUR ACCOUNT", SubCategory: "MFA / TOTP / PIV",
-			Handler: func() error { return cmdself.SelfShowBackupCodeCount(db, user) },
+			Handler: func() error { return cmdself.ShowBackupCodeCount(db, user) },
 		},
 
 		// --- Account ---
 		{
 			Name: "accountList", Description: "List all accounts", Permission: "accountList",
 			Category: "MANAGE OTHER ACCOUNTS", SubCategory: "Accounts",
-			Handler: func() error { return cmdaccount.AccountList(db, user) },
+			Handler: func() error { return cmdaccount.List(db, user) },
 		},
 		{
 			Name: "accountInfo", Description: "Show account info", Permission: "accountInfo",
 			Category: "MANAGE OTHER ACCOUNTS", SubCategory: "Accounts",
 			Args:    []ArgSpec{{"--user", "Username"}},
-			Handler: func() error { return cmdaccount.AccountInfo(db, user, args) },
+			Handler: func() error { return cmdaccount.Info(db, user, args) },
 		},
 		{
 			Name: "accountCreate", Description: "Create a new account", Permission: "accountCreate",
 			Category: "MANAGE OTHER ACCOUNTS", SubCategory: "Accounts",
 			Args:    []ArgSpec{{"--user", "Username to create"}, {"--osh-only", "Restrict to -osh commands"}, {"--superowner", "Grant superowner privileges"}},
-			Handler: func() error { return cmdaccount.AccountCreate(db, adapter, user, args) },
+			Handler: func() error { return cmdaccount.Create(db, adapter, user, args) },
 		},
 		{
 			Name: "accountModify", Description: "Modify an account", Permission: "accountModify",
@@ -201,31 +201,31 @@ func BuildRegistry(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 				{"--oshOnly", "Set osh-only mode (true/false)"},
 				{"--superOwner", "Set superowner mode (true/false)"},
 			},
-			Handler: func() error { return cmdaccount.AccountModify(db, user, args) },
+			Handler: func() error { return cmdaccount.Modify(db, user, args) },
 		},
 		{
 			Name: "accountDelete", Description: "Delete an account", Permission: "accountDelete",
 			Category: "MANAGE OTHER ACCOUNTS", SubCategory: "Accounts",
 			Args:    []ArgSpec{{"--user", "Username to delete"}},
-			Handler: func() error { return cmdaccount.AccountDelete(db, adapter, user, args) },
+			Handler: func() error { return cmdaccount.Delete(db, adapter, user, args) },
 		},
 		{
 			Name: "accountListIngressKeys", Description: "List account ingress keys", Permission: "accountListIngressKeys",
 			Category: "MANAGE OTHER ACCOUNTS", SubCategory: "Account keys",
 			Args:    []ArgSpec{{"--user", "Username"}},
-			Handler: func() error { return cmdaccount.AccountListIngressKeys(db, user, args) },
+			Handler: func() error { return cmdaccount.ListIngressKeys(db, user, args) },
 		},
 		{
 			Name: "accountListEgressKeys", Description: "List account egress keys", Permission: "accountListEgressKeys",
 			Category: "MANAGE OTHER ACCOUNTS", SubCategory: "Account keys",
 			Args:    []ArgSpec{{"--user", "Username"}},
-			Handler: func() error { return cmdaccount.AccountListEgressKeys(db, user, args) },
+			Handler: func() error { return cmdaccount.ListEgressKeys(db, user, args) },
 		},
 		{
 			Name: "accountListAccess", Description: "List account accesses", Permission: "accountListAccess",
 			Category: "MANAGE OTHER ACCOUNTS", SubCategory: "Account accesses",
 			Args:    []ArgSpec{{"--user", "Username"}},
-			Handler: func() error { return cmdaccount.AccountListAccess(db, user, args) },
+			Handler: func() error { return cmdaccount.ListAccess(db, user, args) },
 		},
 		{
 			Name: "accountAddAccess", Description: "Add access to an account", Permission: "accountAddAccess",
@@ -237,13 +237,13 @@ func BuildRegistry(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 				{"--ttl", "Access expiry in days"},
 				{"--protocol", "Protocol restriction: ssh, scpupload, scpdownload, sftp, rsync"},
 			},
-			Handler: func() error { return cmdaccount.AccountAddAccess(db, user, args) },
+			Handler: func() error { return cmdaccount.AddAccess(db, user, args) },
 		},
 		{
 			Name: "accountDelAccess", Description: "Remove access from an account", Permission: "accountDelAccess",
 			Category: "MANAGE OTHER ACCOUNTS", SubCategory: "Account accesses",
 			Args:    []ArgSpec{{"--access", "Access ID"}},
-			Handler: func() error { return cmdaccount.AccountDelAccess(db, user, args) },
+			Handler: func() error { return cmdaccount.DelAccess(db, user, args) },
 		},
 		{
 			Name: "whoHasAccessTo", Description: "List accounts with access to a server", Permission: "whoHasAccessTo",
@@ -255,19 +255,19 @@ func BuildRegistry(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 			Name: "accountDisableTOTP", Description: "Disable TOTP for an account (admin)", Permission: "accountDisableTOTP",
 			Category: "MANAGE OTHER ACCOUNTS", SubCategory: "Account accesses",
 			Args:    []ArgSpec{{"--user", "Username"}},
-			Handler: func() error { return cmdaccount.AccountDisableTOTP(db, user, log, args) },
+			Handler: func() error { return cmdaccount.DisableTOTP(db, user, log, args) },
 		},
 		{
 			Name: "accountSetPassword", Description: "Set/clear password MFA for an account (admin)", Permission: "accountSetPassword",
 			Category: "MANAGE OTHER ACCOUNTS", SubCategory: "Account accesses",
 			Args:    []ArgSpec{{"--user", "Target username"}, {"--clear", "Clear/remove password MFA"}},
-			Handler: func() error { return cmdaccount.AccountSetPassword(db, user, log, args) },
+			Handler: func() error { return cmdaccount.SetPassword(db, user, log, args) },
 		},
 		{
 			Name: "accountDisablePassword", Description: "Disable password MFA for an account (admin)", Permission: "accountSetPassword",
 			Category: "MANAGE OTHER ACCOUNTS", SubCategory: "Account accesses",
 			Args:    []ArgSpec{{"--user", "Target username"}},
-			Handler: func() error { return cmdaccount.AccountDisablePassword(db, user, log, args) },
+			Handler: func() error { return cmdaccount.DisablePassword(db, user, log, args) },
 		},
 
 		// --- PIV ---
@@ -275,18 +275,18 @@ func BuildRegistry(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 			Name: "pivAddTrustAnchor", Description: "Add a PIV/YubiKey CA trust anchor", Permission: "pivAddTrustAnchor",
 			Category: "MANAGE OTHER ACCOUNTS", SubCategory: "Account accesses",
 			Args:    []ArgSpec{{"--name", "Friendly name for this trust anchor"}, {"--cert", "Path to PEM certificate file"}},
-			Handler: func() error { return cmdpiv.PivAddTrustAnchor(db, user, args) },
+			Handler: func() error { return cmdpiv.AddTrustAnchor(db, user, args) },
 		},
 		{
 			Name: "pivListTrustAnchors", Description: "List PIV trust anchor CAs", Permission: "pivListTrustAnchors",
 			Category: "MANAGE OTHER ACCOUNTS", SubCategory: "Account accesses",
-			Handler: func() error { return cmdpiv.PivListTrustAnchors(db, user, args) },
+			Handler: func() error { return cmdpiv.ListTrustAnchors(db, user, args) },
 		},
 		{
 			Name: "pivRemoveTrustAnchor", Description: "Remove a PIV trust anchor CA", Permission: "pivRemoveTrustAnchor",
 			Category: "MANAGE OTHER ACCOUNTS", SubCategory: "Account accesses",
 			Args:    []ArgSpec{{"--name", "Name of the trust anchor to remove"}},
-			Handler: func() error { return cmdpiv.PivRemoveTrustAnchor(db, user, args) },
+			Handler: func() error { return cmdpiv.RemoveTrustAnchor(db, user, args) },
 		},
 
 		// --- Realms ---
@@ -300,24 +300,24 @@ func BuildRegistry(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 				{"--from", "Trusted source CIDRs"},
 				{"--public-key", "Trusted realm SSH public key"},
 			},
-			Handler: func() error { return cmdrealm.RealmCreate(db, user, args) },
+			Handler: func() error { return cmdrealm.Create(db, user, args) },
 		},
 		{
 			Name: "realmList", Description: "List configured realms", Permission: "realmList",
 			Category: "RESTRICTED OPERATIONS", SubCategory: "Realms",
-			Handler: func() error { return cmdrealm.RealmList(db, user, args) },
+			Handler: func() error { return cmdrealm.List(db, user, args) },
 		},
 		{
 			Name: "realmInfo", Description: "Show details for one realm", Permission: "realmInfo",
 			Category: "RESTRICTED OPERATIONS", SubCategory: "Realms",
 			Args:    []ArgSpec{{"--realm", "Realm name"}},
-			Handler: func() error { return cmdrealm.RealmInfo(db, user, args) },
+			Handler: func() error { return cmdrealm.Info(db, user, args) },
 		},
 		{
 			Name: "realmDelete", Description: "Delete a realm configuration", Permission: "realmDelete",
 			Category: "RESTRICTED OPERATIONS", SubCategory: "Realms",
 			Args:    []ArgSpec{{"--realm", "Realm name"}},
-			Handler: func() error { return cmdrealm.RealmDelete(db, user, args) },
+			Handler: func() error { return cmdrealm.Delete(db, user, args) },
 		},
 
 		// --- Restricted grants ---
@@ -325,19 +325,19 @@ func BuildRegistry(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 			Name: "restrictedGrantAdd", Description: "Grant a restricted command to a user", Permission: "restrictedGrantAdd",
 			Category: "RESTRICTED OPERATIONS", SubCategory: "Command grants",
 			Args:    []ArgSpec{{"--user", "Target username"}, {"--command", "Restricted command name"}},
-			Handler: func() error { return cmdrestricted.RestrictedGrantAdd(db, user, args) },
+			Handler: func() error { return cmdrestricted.GrantAdd(db, user, args) },
 		},
 		{
 			Name: "restrictedGrantDel", Description: "Remove a restricted command grant", Permission: "restrictedGrantDel",
 			Category: "RESTRICTED OPERATIONS", SubCategory: "Command grants",
 			Args:    []ArgSpec{{"--user", "Target username"}, {"--command", "Restricted command name"}},
-			Handler: func() error { return cmdrestricted.RestrictedGrantDel(db, user, args) },
+			Handler: func() error { return cmdrestricted.GrantDel(db, user, args) },
 		},
 		{
 			Name: "restrictedGrantList", Description: "List restricted command grants", Permission: "restrictedGrantList",
 			Category: "RESTRICTED OPERATIONS", SubCategory: "Command grants",
 			Args:    []ArgSpec{{"--user", "Optional username filter"}},
-			Handler: func() error { return cmdrestricted.RestrictedGrantList(db, user, args) },
+			Handler: func() error { return cmdrestricted.GrantList(db, user, args) },
 		},
 
 		// --- Groups: Overview ---
@@ -345,25 +345,25 @@ func BuildRegistry(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 			Name: "groupInfo", Description: "Show group info", Permission: "groupInfo",
 			Category: "MANAGE GROUPS", SubCategory: "Groups",
 			Args:    []ArgSpec{{"--group", "Group name"}},
-			Handler: func() error { return cmdgroup.GroupInfo(db, user, args) },
+			Handler: func() error { return cmdgroup.Info(db, user, args) },
 		},
 		{
 			Name: "groupList", Description: "List groups", Permission: "groupList",
 			Category: "MANAGE GROUPS", SubCategory: "Groups",
 			Args:    []ArgSpec{{"--all", "Show all groups"}},
-			Handler: func() error { return cmdgroup.GroupList(db, user, args) },
+			Handler: func() error { return cmdgroup.List(db, user, args) },
 		},
 		{
 			Name: "groupCreate", Description: "Create a new group", Permission: "groupCreate",
 			Category: "MANAGE GROUPS", SubCategory: "Groups",
 			Args:    []ArgSpec{{"--group", "Group name"}},
-			Handler: func() error { return cmdgroup.GroupCreate(db, user, args) },
+			Handler: func() error { return cmdgroup.Create(db, user, args) },
 		},
 		{
 			Name: "groupDelete", Description: "Delete a group", Permission: "groupDelete",
 			Category: "MANAGE GROUPS", SubCategory: "Groups",
 			Args:    []ArgSpec{{"--group", "Group name"}},
-			Handler: func() error { return cmdgroup.GroupDelete(db, user, args) },
+			Handler: func() error { return cmdgroup.Delete(db, user, args) },
 		},
 
 		// --- Groups: Members ---
@@ -374,13 +374,13 @@ func BuildRegistry(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 				{"--group", "Group name"}, {"--user", "Username to add"},
 				{"--role", "Role (owner, aclkeeper, gatekeeper, member, guest)"},
 			},
-			Handler: func() error { return cmdgroup.GroupAddMember(db, user, args) },
+			Handler: func() error { return cmdgroup.AddMember(db, user, args) },
 		},
 		{
 			Name: "groupDelMember", Description: "Remove a member from a group", Permission: "groupDelMember",
 			Category: "MANAGE GROUPS", SubCategory: "Group member management",
 			Args:    []ArgSpec{{"--group", "Group name"}, {"--user", "Username to remove"}},
-			Handler: func() error { return cmdgroup.GroupDelMember(db, user, args) },
+			Handler: func() error { return cmdgroup.DelMember(db, user, args) },
 		},
 
 		// --- Groups: Egress ---
@@ -388,7 +388,7 @@ func BuildRegistry(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 			Name: "groupListEgressKeys", Description: "List group egress keys", Permission: "groupListEgressKeys",
 			Category: "MANAGE GROUPS", SubCategory: "Group egress (bastion → server)",
 			Args:    []ArgSpec{{"--group", "Group name"}},
-			Handler: func() error { return cmdgroup.GroupListEgressKeys(db, user, args) },
+			Handler: func() error { return cmdgroup.ListEgressKeys(db, user, args) },
 		},
 		{
 			Name: "groupGenerateEgressKey", Description: "Generate a new group egress key", Permission: "groupGenerateEgressKey",
@@ -397,7 +397,7 @@ func BuildRegistry(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 				{"--group", "Group name"}, {"--type", "Key type"}, {"--size", "Key size"},
 				{"--comment", "Key comment"},
 			},
-			Handler: func() error { return cmdgroup.GroupGenerateEgressKey(db, user, args) },
+			Handler: func() error { return cmdgroup.GenerateEgressKey(db, user, args) },
 		},
 
 		// --- Groups: Accesses ---
@@ -405,7 +405,7 @@ func BuildRegistry(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 			Name: "groupListAccesses", Description: "List accesses of the group", Permission: "groupListAccesses",
 			Category: "MANAGE GROUPS", SubCategory: "Group accesses",
 			Args:    []ArgSpec{{"--group", "Group name"}},
-			Handler: func() error { return cmdgroup.GroupListAccesses(db, user, args) },
+			Handler: func() error { return cmdgroup.ListAccesses(db, user, args) },
 		},
 		{
 			Name: "groupAddAccess", Description: "Add access to a group", Permission: "groupAddAccess",
@@ -419,13 +419,13 @@ func BuildRegistry(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 				{"--guest", "Allow guest role members to use this access"},
 				{"--force", "Skip connectivity check"},
 			},
-			Handler: func() error { return cmdgroup.GroupAddAccess(db, user, args) },
+			Handler: func() error { return cmdgroup.AddAccess(db, user, args) },
 		},
 		{
 			Name: "groupDelAccess", Description: "Remove access from a group", Permission: "groupDelAccess",
 			Category: "MANAGE GROUPS", SubCategory: "Group accesses",
 			Args:    []ArgSpec{{"--group", "Group name"}, {"--access", "Access ID to remove"}},
-			Handler: func() error { return cmdgroup.GroupDelAccess(db, user, args) },
+			Handler: func() error { return cmdgroup.DelAccess(db, user, args) },
 		},
 		{
 			Name: "groupSetMFA", Description: "Enable/disable JIT MFA requirement for a group", Permission: "groupSetMFA",
@@ -434,7 +434,7 @@ func BuildRegistry(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 				{"--group", "Group name"}, {"--required", "Require MFA for this group"},
 				{"--optional", "Remove MFA requirement for this group"},
 			},
-			Handler: func() error { return cmdgroup.GroupSetMFA(db, user, log, args) },
+			Handler: func() error { return cmdgroup.SetMFA(db, user, log, args) },
 		},
 
 		// --- Groups: Aliases ---
@@ -442,19 +442,19 @@ func BuildRegistry(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 			Name: "groupAddAlias", Description: "Add a group alias", Permission: "groupAddAlias",
 			Category: "MANAGE GROUPS", SubCategory: "Group alias (group)",
 			Args:    []ArgSpec{{"--group", "Group name"}, {"--alias", "Alias"}, {"--hostname", "Host name"}},
-			Handler: func() error { return cmdgroup.GroupAddAlias(db, user, args) },
+			Handler: func() error { return cmdgroup.AddAlias(db, user, args) },
 		},
 		{
 			Name: "groupDelAlias", Description: "Delete a group alias", Permission: "groupDelAlias",
 			Category: "MANAGE GROUPS", SubCategory: "Group alias (group)",
 			Args:    []ArgSpec{{"--group", "Group name"}, {"--id", "Alias ID"}},
-			Handler: func() error { return cmdgroup.GroupDelAlias(db, user, args) },
+			Handler: func() error { return cmdgroup.DelAlias(db, user, args) },
 		},
 		{
 			Name: "groupListAliases", Description: "List group aliases", Permission: "groupListAliases",
 			Category: "MANAGE GROUPS", SubCategory: "Group alias (group)",
 			Args:    []ArgSpec{{"--group", "Group name"}},
-			Handler: func() error { return cmdgroup.GroupListAliases(db, user, args) },
+			Handler: func() error { return cmdgroup.ListAliases(db, user, args) },
 		},
 
 		// --- TTY ---
@@ -465,13 +465,13 @@ func BuildRegistry(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 				{"--startDate", "Start date"}, {"--endDate", "End date"},
 				{"--host", "Filter by server hostname"},
 			},
-			Handler: func() error { return cmdtty.TtyList(db, user, args) },
+			Handler: func() error { return cmdtty.List(db, user, args) },
 		},
 		{
 			Name: "ttyPlay", Description: "Replay a recorded tty session", Permission: "ttyPlay",
 			Category: "TTY SESSIONS", SubCategory: "",
 			Args:    []ArgSpec{{"--file", "File name"}},
-			Handler: func() error { return cmdtty.TtyPlay(db, user, args) },
+			Handler: func() error { return cmdtty.Play(db, user, args) },
 		},
 
 		// --- Misc ---

--- a/internal/commands/restricted/grants.go
+++ b/internal/commands/restricted/grants.go
@@ -17,8 +17,8 @@ func normalizeCommandName(cmd string) string {
 	return strings.TrimSpace(cmd)
 }
 
-// RestrictedGrantAdd grants a restricted command to a target user.
-func RestrictedGrantAdd(db *gorm.DB, currentUser *models.User, args []string) error {
+// GrantAdd grants a restricted command to a target user.
+func GrantAdd(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("restrictedGrantAdd", flag.ContinueOnError)
 	var username, command string
 	fs.StringVar(&username, "user", "", "Target username")
@@ -66,8 +66,8 @@ func RestrictedGrantAdd(db *gorm.DB, currentUser *models.User, args []string) er
 	return nil
 }
 
-// RestrictedGrantDel removes a restricted command grant from a target user.
-func RestrictedGrantDel(db *gorm.DB, currentUser *models.User, args []string) error {
+// GrantDel removes a restricted command grant from a target user.
+func GrantDel(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("restrictedGrantDel", flag.ContinueOnError)
 	var username, command string
 	fs.StringVar(&username, "user", "", "Target username")
@@ -114,8 +114,8 @@ func RestrictedGrantDel(db *gorm.DB, currentUser *models.User, args []string) er
 	return nil
 }
 
-// RestrictedGrantList lists restricted command grants, optionally filtered by user.
-func RestrictedGrantList(db *gorm.DB, currentUser *models.User, args []string) error {
+// GrantList lists restricted command grants, optionally filtered by user.
+func GrantList(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("restrictedGrantList", flag.ContinueOnError)
 	var username string
 	fs.StringVar(&username, "user", "", "Optional username filter")

--- a/internal/commands/self/add_access.go
+++ b/internal/commands/self/add_access.go
@@ -16,8 +16,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// SelfAddAccess adds a personal SSH access entry for the current user.
-func SelfAddAccess(db *gorm.DB, user *models.User, args []string) error {
+// AddAccess adds a personal SSH access entry for the current user.
+func AddAccess(db *gorm.DB, user *models.User, args []string) error {
 
 	fs := flag.NewFlagSet("selfAddAccess", flag.ContinueOnError)
 	var server, username, comment, allowedFrom, protocol string

--- a/internal/commands/self/add_access_test.go
+++ b/internal/commands/self/add_access_test.go
@@ -6,11 +6,11 @@ import (
 	"goBastion/internal/models"
 )
 
-func TestSelfAddAccess_Success(t *testing.T) {
+func TestAddAccess_Success(t *testing.T) {
 	db := newTestDB(t)
 	user := newRegularUser(t, db, "alice")
 
-	err := SelfAddAccess(db, user, []string{
+	err := AddAccess(db, user, []string{
 		"--server", "1.2.3.4",
 		"--username", "root",
 		"--port", "22",
@@ -27,12 +27,12 @@ func TestSelfAddAccess_Success(t *testing.T) {
 	}
 }
 
-func TestSelfAddAccess_MissingServer(t *testing.T) {
+func TestAddAccess_MissingServer(t *testing.T) {
 	db := newTestDB(t)
 	user := newRegularUser(t, db, "alice")
 
 	// Missing --server; should not panic, no DB entry
-	_ = SelfAddAccess(db, user, []string{
+	_ = AddAccess(db, user, []string{
 		"--username", "root",
 		"--port", "22",
 	})

--- a/internal/commands/self/add_alias.go
+++ b/internal/commands/self/add_alias.go
@@ -11,8 +11,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// SelfAddAlias creates an alias for a personal access target.
-func SelfAddAlias(db *gorm.DB, user *models.User, args []string) error {
+// AddAlias creates an alias for a personal access target.
+func AddAlias(db *gorm.DB, user *models.User, args []string) error {
 	fs := flag.NewFlagSet("selfAddAlias", flag.ContinueOnError)
 	var alias, hostname string
 	fs.StringVar(&alias, "alias", "", "Alias")

--- a/internal/commands/self/add_ingress_key.go
+++ b/internal/commands/self/add_ingress_key.go
@@ -18,8 +18,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// SelfAddIngressKey adds a new ingress SSH key for the current user.
-func SelfAddIngressKey(db *gorm.DB, user *models.User, args []string) error {
+// AddIngressKey adds a new ingress SSH key for the current user.
+func AddIngressKey(db *gorm.DB, user *models.User, args []string) error {
 	fs := flag.NewFlagSet("selfAddIngressKey", flag.ContinueOnError)
 	var pubKey string
 	var expiresDays int

--- a/internal/commands/self/add_ingress_key_piv.go
+++ b/internal/commands/self/add_ingress_key_piv.go
@@ -60,7 +60,7 @@ func addIngressKey(db *gorm.DB, user *models.User, pubKeyText, comment string, p
 // the key is accepted.
 //
 // Usage: selfAddIngressKeyPIV --attest <path> --intermediate <path> [--comment <comment>]
-func SelfAddIngressKeyPIV(db *gorm.DB, currentUser *models.User, args []string) error {
+func AddIngressKeyPIV(db *gorm.DB, currentUser *models.User, args []string) error {
 	fs := flag.NewFlagSet("selfAddIngressKeyPIV", flag.ContinueOnError)
 	var attestFile, intermediateFile, comment string
 	fs.StringVar(&attestFile, "attest", "", "Path to PIV attestation certificate (PEM)")

--- a/internal/commands/self/add_ingress_key_test.go
+++ b/internal/commands/self/add_ingress_key_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 )
 
-func TestSelfAddIngressKey_InvalidKeyNoArgs(t *testing.T) {
+func TestAddIngressKey_InvalidKeyNoArgs(t *testing.T) {
 	db := newTestDB(t)
 	user := newRegularUser(t, db, "alice")
 
 	// No args — should not panic; returns nil (empty key path returns nil)
-	_ = SelfAddIngressKey(db, user, []string{})
+	_ = AddIngressKey(db, user, []string{})
 }

--- a/internal/commands/self/backup_codes.go
+++ b/internal/commands/self/backup_codes.go
@@ -12,9 +12,9 @@ import (
 	"gorm.io/gorm"
 )
 
-// SelfGenerateBackupCodes generates new TOTP backup codes for the current user.
+// GenerateBackupCodes generates new TOTP backup codes for the current user.
 // Any previously existing codes are invalidated.
-func SelfGenerateBackupCodes(db *gorm.DB, user *models.User, log *slog.Logger) error {
+func GenerateBackupCodes(db *gorm.DB, user *models.User, log *slog.Logger) error {
 	plainCodes, jsonHashes, err := totp.GenerateBackupCodes()
 	if err != nil {
 		return fmt.Errorf("failed to generate backup codes: %w", err)
@@ -52,8 +52,8 @@ func SelfGenerateBackupCodes(db *gorm.DB, user *models.User, log *slog.Logger) e
 	return nil
 }
 
-// SelfShowBackupCodeCount shows how many backup codes remain.
-func SelfShowBackupCodeCount(db *gorm.DB, user *models.User) error {
+// ShowBackupCodeCount shows how many backup codes remain.
+func ShowBackupCodeCount(db *gorm.DB, user *models.User) error {
 	count := totp.CountBackupCodes(user.BackupCodes)
 	if count == 0 {
 		console.DisplayBlock(console.ContentBlock{

--- a/internal/commands/self/change_password.go
+++ b/internal/commands/self/change_password.go
@@ -11,8 +11,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// SelfChangePassword changes the user's password MFA, verifying the current password first.
-func SelfChangePassword(db *gorm.DB, user *models.User, log *slog.Logger, args []string) error {
+// ChangePassword changes the user's password MFA, verifying the current password first.
+func ChangePassword(db *gorm.DB, user *models.User, log *slog.Logger, args []string) error {
 	if user.PasswordHash == "" {
 		console.DisplayBlock(console.ContentBlock{
 			Title: "Change Password MFA", BlockType: "error",

--- a/internal/commands/self/del_access.go
+++ b/internal/commands/self/del_access.go
@@ -14,8 +14,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// SelfDelAccess removes a personal SSH access entry for the current user.
-func SelfDelAccess(db *gorm.DB, user *models.User, args []string) error {
+// DelAccess removes a personal SSH access entry for the current user.
+func DelAccess(db *gorm.DB, user *models.User, args []string) error {
 	fs := flag.NewFlagSet("selfDelAccess", flag.ContinueOnError)
 	var accessID uuid.UUID
 	fs.Func("id", "Access ID", func(s string) error {

--- a/internal/commands/self/del_access_test.go
+++ b/internal/commands/self/del_access_test.go
@@ -6,7 +6,7 @@ import (
 	"goBastion/internal/models"
 )
 
-func TestSelfDelAccess_Success(t *testing.T) {
+func TestDelAccess_Success(t *testing.T) {
 	db := newTestDB(t)
 	user := newRegularUser(t, db, "alice")
 
@@ -22,10 +22,10 @@ func TestSelfDelAccess_Success(t *testing.T) {
 		t.Fatalf("create access: %v", err)
 	}
 
-	// Note: SelfDelAccess uses flag.Func whose String() always returns "",
+	// Note: DelAccess uses flag.Func whose String() always returns "",
 	// so the "id empty" guard triggers and the function returns nil without deleting.
 	// This test verifies the function does not panic or return an error.
-	err := SelfDelAccess(db, user, []string{"--id", access.ID.String()})
+	err := DelAccess(db, user, []string{"--id", access.ID.String()})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/commands/self/del_alias.go
+++ b/internal/commands/self/del_alias.go
@@ -14,8 +14,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// SelfDelAlias removes a personal alias.
-func SelfDelAlias(db *gorm.DB, user *models.User, args []string) error {
+// DelAlias removes a personal alias.
+func DelAlias(db *gorm.DB, user *models.User, args []string) error {
 	fs := flag.NewFlagSet("selfDelAlias", flag.ContinueOnError)
 	var hostID string
 	fs.StringVar(&hostID, "id", "", "Alias ID")

--- a/internal/commands/self/del_ingress_key.go
+++ b/internal/commands/self/del_ingress_key.go
@@ -13,8 +13,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// SelfDelIngressKey removes an ingress SSH key for the current user.
-func SelfDelIngressKey(db *gorm.DB, user *models.User, args []string) error {
+// DelIngressKey removes an ingress SSH key for the current user.
+func DelIngressKey(db *gorm.DB, user *models.User, args []string) error {
 	fs := flag.NewFlagSet("selfDelIngressKey", flag.ContinueOnError)
 	var keyId string
 	fs.StringVar(&keyId, "id", "", "SSH public key ID")

--- a/internal/commands/self/disable_password.go
+++ b/internal/commands/self/disable_password.go
@@ -11,8 +11,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// SelfDisablePassword lets a user disable their password-based MFA after verifying the current password.
-func SelfDisablePassword(db *gorm.DB, user *models.User, log *slog.Logger, args []string) error {
+// DisablePassword lets a user disable their password-based MFA after verifying the current password.
+func DisablePassword(db *gorm.DB, user *models.User, log *slog.Logger, args []string) error {
 	if user.PasswordHash == "" {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Disable Password MFA",

--- a/internal/commands/self/generate_egress_key.go
+++ b/internal/commands/self/generate_egress_key.go
@@ -21,8 +21,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// SelfGenerateEgressKey generates a new SSH egress key pair for the current user.
-func SelfGenerateEgressKey(db *gorm.DB, user *models.User, args []string) error {
+// GenerateEgressKey generates a new SSH egress key pair for the current user.
+func GenerateEgressKey(db *gorm.DB, user *models.User, args []string) error {
 	fs := flag.NewFlagSet("selfGenerateEgressKey", flag.ContinueOnError)
 	var keyType string
 	var keySize int
@@ -98,7 +98,7 @@ func SelfGenerateEgressKey(db *gorm.DB, user *models.User, args []string) error 
 		})
 		return fmt.Errorf("error reading private key: %v", err)
 	}
-	pubKeyStr, err := os.ReadFile(tmpFile + ".pub")
+	pubKeyData, err := os.ReadFile(tmpFile + ".pub")
 	if err != nil {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Generate Egress Key",
@@ -109,7 +109,7 @@ func SelfGenerateEgressKey(db *gorm.DB, user *models.User, args []string) error 
 		})
 		return fmt.Errorf("error reading public key: %v", err)
 	}
-	pubKey, _, _, _, err := ssh.ParseAuthorizedKey(pubKeyStr)
+	pubKey, _, _, _, err := ssh.ParseAuthorizedKey(pubKeyData)
 	if err != nil || pubKey == nil {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Generate Egress Key",
@@ -132,7 +132,7 @@ func SelfGenerateEgressKey(db *gorm.DB, user *models.User, args []string) error 
 
 	newKey := models.SelfEgressKey{
 		UserID:      user.ID,
-		PubKey:      strings.TrimSpace(string(pubKeyStr)),
+		PubKey:      strings.TrimSpace(string(pubKeyData)),
 		PrivKey:     encrypted,
 		Type:        keyType,
 		Size:        keySize,

--- a/internal/commands/self/list_accesses.go
+++ b/internal/commands/self/list_accesses.go
@@ -13,8 +13,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// SelfListAccesses lists all personal SSH accesses for the current user.
-func SelfListAccesses(db *gorm.DB, user *models.User) error {
+// ListAccesses lists all personal SSH accesses for the current user.
+func ListAccesses(db *gorm.DB, user *models.User) error {
 	var accesses []models.SelfAccess
 	result := db.Where("user_id = ?", user.ID).Find(&accesses)
 	if result.Error != nil {
@@ -45,17 +45,17 @@ func SelfListAccesses(db *gorm.DB, user *models.User) error {
 		if !access.LastConnection.IsZero() {
 			lastUsed = access.LastConnection.Format("2006-01-02 15:04:05")
 		}
-		expiresStr := "Never"
+		expires := "Never"
 		if access.ExpiresAt != nil {
 			if access.ExpiresAt.Before(time.Now()) {
-				expiresStr = "EXPIRED(" + access.ExpiresAt.Format("2006-01-02") + ")"
+				expires = "EXPIRED(" + access.ExpiresAt.Format("2006-01-02") + ")"
 			} else {
-				expiresStr = access.ExpiresAt.Format("2006-01-02")
+				expires = access.ExpiresAt.Format("2006-01-02")
 			}
 		}
-		fromStr := access.AllowedFrom
-		if fromStr == "" {
-			fromStr = "*"
+		allowedFrom := access.AllowedFrom
+		if allowedFrom == "" {
+			allowedFrom = "*"
 		}
 		proto := access.Protocol
 		if proto == "" {
@@ -68,8 +68,8 @@ func SelfListAccesses(db *gorm.DB, user *models.User) error {
 			access.Port,
 			proto,
 			access.Comment,
-			fromStr,
-			expiresStr,
+			allowedFrom,
+			expires,
 			lastUsed,
 			access.CreatedAt.Format("2006-01-02 15:04:05"),
 		)

--- a/internal/commands/self/list_aliases.go
+++ b/internal/commands/self/list_aliases.go
@@ -12,8 +12,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// SelfListAliases lists all personal aliases for the current user.
-func SelfListAliases(db *gorm.DB, user *models.User) error {
+// ListAliases lists all personal aliases for the current user.
+func ListAliases(db *gorm.DB, user *models.User) error {
 	var hosts []models.Aliases
 	result := db.Where("user_id = ?", user.ID).Find(&hosts)
 	if result.Error != nil {

--- a/internal/commands/self/list_egress_keys.go
+++ b/internal/commands/self/list_egress_keys.go
@@ -9,8 +9,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// SelfListEgressKeys lists all egress SSH keys for the current user.
-func SelfListEgressKeys(db *gorm.DB, user *models.User) error {
+// ListEgressKeys lists all egress SSH keys for the current user.
+func ListEgressKeys(db *gorm.DB, user *models.User) error {
 	var keys []models.SelfEgressKey
 	result := db.Where("user_id = ?", user.ID).Find(&keys)
 	if result.Error != nil {

--- a/internal/commands/self/list_ingress_keys.go
+++ b/internal/commands/self/list_ingress_keys.go
@@ -10,8 +10,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// SelfListIngressKeys lists all ingress SSH keys for the current user.
-func SelfListIngressKeys(db *gorm.DB, user *models.User) error {
+// ListIngressKeys lists all ingress SSH keys for the current user.
+func ListIngressKeys(db *gorm.DB, user *models.User) error {
 	var keys []models.IngressKey
 	if err := db.Where("user_id = ?", user.ID).Find(&keys).Error; err != nil {
 		console.DisplayBlock(console.ContentBlock{
@@ -35,25 +35,25 @@ func SelfListIngressKeys(db *gorm.DB, user *models.User) error {
 	}
 	var sections []console.SectionContent
 	for _, key := range keys {
-		expiresStr := "Never"
+		expires := "Never"
 		if key.ExpiresAt != nil {
 			if key.ExpiresAt.Before(time.Now()) {
-				expiresStr = "⚠️ EXPIRED (" + key.ExpiresAt.Format("2006-01-02") + ")"
+				expires = "⚠️ EXPIRED (" + key.ExpiresAt.Format("2006-01-02") + ")"
 			} else {
-				expiresStr = key.ExpiresAt.Format("2006-01-02")
+				expires = key.ExpiresAt.Format("2006-01-02")
 			}
 		}
-		pivStr := ""
+		pivLabel := ""
 		if key.PIVAttested {
-			pivStr = " 🔐 PIV-attested"
+			pivLabel = " 🔐 PIV-attested"
 		}
 		section := console.SectionContent{
 			SubTitle: fmt.Sprintf("Key ID: %s", key.ID.String()),
 			Body: []string{
-				fmt.Sprintf("Type: %s%s", key.Type, pivStr),
+				fmt.Sprintf("Type: %s%s", key.Type, pivLabel),
 				fmt.Sprintf("Fingerprint: %s", key.Fingerprint),
 				fmt.Sprintf("Size: %d", key.Size),
-				fmt.Sprintf("Expires: %s", expiresStr),
+				fmt.Sprintf("Expires: %s", expires),
 				fmt.Sprintf("Last Update: %s", key.UpdatedAt.Format("2006-01-02 15:04:05")),
 				fmt.Sprintf("Public Key: %s", key.Key),
 			},

--- a/internal/commands/self/remove_host_from_known_hosts.go
+++ b/internal/commands/self/remove_host_from_known_hosts.go
@@ -16,13 +16,13 @@ import (
 	"gorm.io/gorm"
 )
 
-// SelfRemoveHostFromKnownHosts removes all known_hosts entries for a host from the DB and syncs to disk.
-func SelfRemoveHostFromKnownHosts(db *gorm.DB, u *models.User, args []string) error {
+// RemoveHostFromKnownHosts removes all known_hosts entries for a host from the DB and syncs to disk.
+func RemoveHostFromKnownHosts(db *gorm.DB, u *models.User, args []string) error {
 	return removeHostFromKnownHosts(db, u, args, false)
 }
 
-// SelfReplaceKnownHost removes the stored key for a host so the new key is trusted on next connection.
-func SelfReplaceKnownHost(db *gorm.DB, u *models.User, args []string) error {
+// ReplaceKnownHost removes the stored key for a host so the new key is trusted on next connection.
+func ReplaceKnownHost(db *gorm.DB, u *models.User, args []string) error {
 	return removeHostFromKnownHosts(db, u, args, true)
 }
 

--- a/internal/commands/self/set_password.go
+++ b/internal/commands/self/set_password.go
@@ -11,9 +11,9 @@ import (
 	"gorm.io/gorm"
 )
 
-// SelfSetPassword sets a password-based MFA second factor for the current user.
+// SetPassword sets a password-based MFA second factor for the current user.
 // The password is stored as a bcrypt hash. It will be required at every login in addition to key auth.
-func SelfSetPassword(db *gorm.DB, user *models.User, log *slog.Logger, args []string) error {
+func SetPassword(db *gorm.DB, user *models.User, log *slog.Logger, args []string) error {
 	fmt.Print("Enter new password: ")
 	pass1, err := readPassword()
 	if err != nil {

--- a/internal/commands/ssh/connect.go
+++ b/internal/commands/ssh/connect.go
@@ -44,8 +44,8 @@ type accessCandidate struct {
 	reason      string
 }
 
-// SSHConnect resolves the target and establishes an SSH connection through the bastion.
-func SSHConnect(db *gorm.DB, user models.User, logger slog.Logger, params string) error {
+// Connect resolves the target and establishes an SSH connection through the bastion.
+func Connect(db *gorm.DB, user models.User, logger slog.Logger, params string) error {
 	// Extract -F forwarding hops before parsing the main target.
 	cleanParams, hops, err := extractForwardHops(params)
 	if err != nil {
@@ -839,7 +839,7 @@ func TCPProxy(db *gorm.DB, user models.User, logger slog.Logger, host, port stri
 	return nil
 }
 
-// SftpSession handles sftp passthrough by acting as a minimal SSH server on
+// SFTPSession handles sftp passthrough by acting as a minimal SSH server on
 // stdin/stdout, connecting to the target with the bastion's egress key and
 // proxying the sftp subsystem — no client key on the target needed.
 //
@@ -852,7 +852,7 @@ func TCPProxy(db *gorm.DB, user models.User, logger slog.Logger, host, port stri
 //	ProxyCommand ssh -p 2222 -- user@bastion "sftp-session root@%h:%p"
 //	StrictHostKeyChecking no
 //	UserKnownHostsFile /dev/null
-func SftpSession(db *gorm.DB, user models.User, logger slog.Logger, params string) error {
+func SFTPSession(db *gorm.DB, user models.User, logger slog.Logger, params string) error {
 	sshUser, sshHost, sshPort, _, err := parseSSHCommand(params)
 	if err != nil {
 		return fmt.Errorf("invalid sftp-session command: %v", err)

--- a/internal/commands/ssh/connect_test.go
+++ b/internal/commands/ssh/connect_test.go
@@ -329,7 +329,7 @@ func TestParseSSHCommand(t *testing.T) {
 		wantHost   string
 		wantPort   string
 		wantCmd    string
-		wantErrStr string
+		wantErr string
 	}{
 		{"user@host", "deploy@myserver", "deploy", "myserver", "22", "", ""},
 		{"user@host:port", "deploy@myserver:2222", "deploy", "myserver", "2222", "", ""},
@@ -342,9 +342,9 @@ func TestParseSSHCommand(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			u, h, p, cmd, err := parseSSHCommand(tc.input)
-			if tc.wantErrStr != "" {
-				if err == nil || !strings.Contains(err.Error(), tc.wantErrStr) {
-					t.Errorf("expected error containing %q, got %v", tc.wantErrStr, err)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("expected error containing %q, got %v", tc.wantErr, err)
 				}
 				return
 			}

--- a/internal/commands/totp/disable_totp.go
+++ b/internal/commands/totp/disable_totp.go
@@ -14,9 +14,9 @@ import (
 	"gorm.io/gorm"
 )
 
-// SelfDisableTOTP verifies the current TOTP code before disabling it, preventing a stolen
+// DisableTOTP verifies the current TOTP code before disabling it, preventing a stolen
 // session from silently removing MFA.
-func SelfDisableTOTP(db *gorm.DB, user *models.User, log *slog.Logger) error {
+func DisableTOTP(db *gorm.DB, user *models.User, log *slog.Logger) error {
 	if !user.TOTPEnabled {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Disable TOTP",

--- a/internal/commands/totp/setup_totp.go
+++ b/internal/commands/totp/setup_totp.go
@@ -15,9 +15,9 @@ import (
 	"gorm.io/gorm"
 )
 
-// SelfSetupTOTP generates a TOTP secret, shows the enrollment URL, and asks the user to
+// SetupTOTP generates a TOTP secret, shows the enrollment URL, and asks the user to
 // confirm a code before persisting. This ensures the authenticator app is correctly set up.
-func SelfSetupTOTP(db *gorm.DB, user *models.User, log *slog.Logger) error {
+func SetupTOTP(db *gorm.DB, user *models.User, log *slog.Logger) error {
 	if user.TOTPEnabled {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Setup TOTP",

--- a/internal/commands/tty/list.go
+++ b/internal/commands/tty/list.go
@@ -17,16 +17,16 @@ import (
 	"gorm.io/gorm"
 )
 
-// TtyList lists recorded TTY sessions for a user.
-func TtyList(db *gorm.DB, u *models.User, args []string) error {
+// List lists recorded TTY sessions for a user.
+func List(db *gorm.DB, u *models.User, args []string) error {
 	fs := flag.NewFlagSet("ttyList", flag.ContinueOnError)
-	var startDateStr, endDateStr, hostFilter string
+	var startDate, endDate, hostFilter string
 	var username string
 	if u.IsAdmin() {
 		fs.StringVar(&username, "user", "", "Username (admin only)")
 	}
-	fs.StringVar(&startDateStr, "startDate", "", "From date (YYYY-MM-DD)")
-	fs.StringVar(&endDateStr, "endDate", "", "To date (YYYY-MM-DD)")
+	fs.StringVar(&startDate, "startDate", "", "From date (YYYY-MM-DD)")
+	fs.StringVar(&endDate, "endDate", "", "To date (YYYY-MM-DD)")
 	fs.StringVar(&hostFilter, "host", "", "Filter by server hostname")
 	var flagOutput bytes.Buffer
 	fs.SetOutput(&flagOutput)
@@ -107,29 +107,29 @@ func TtyList(db *gorm.DB, u *models.User, args []string) error {
 						continue
 					}
 				}
-				dateStr, valid := extractDate(name)
+				date, valid := extractDate(name)
 				if !valid {
 					continue
 				}
-				if startDateStr != "" {
-					start, err := time.Parse("2006-01-02", startDateStr)
+				if startDate != "" {
+					start, err := time.Parse("2006-01-02", startDate)
 					if err == nil {
-						d, _ := time.Parse("2006-01-02", dateStr)
+						d, _ := time.Parse("2006-01-02", date)
 						if d.Before(start) {
 							continue
 						}
 					}
 				}
-				if endDateStr != "" {
-					end, err := time.Parse("2006-01-02", endDateStr)
+				if endDate != "" {
+					end, err := time.Parse("2006-01-02", endDate)
 					if err == nil {
-						d, _ := time.Parse("2006-01-02", dateStr)
+						d, _ := time.Parse("2006-01-02", date)
 						if d.After(end) {
 							continue
 						}
 					}
 				}
-				filesByDate[dateStr] = append(filesByDate[dateStr], name)
+				filesByDate[date] = append(filesByDate[date], name)
 			}
 			if len(filesByDate) == 0 {
 				return nil

--- a/internal/commands/tty/list_test.go
+++ b/internal/commands/tty/list_test.go
@@ -26,14 +26,14 @@ func newTestDB(t *testing.T) *gorm.DB {
 	return db
 }
 
-func TestTtyList_NoArgs(t *testing.T) {
+func TestList_NoArgs(t *testing.T) {
 	db := newTestDB(t)
 	user := models.User{Username: "alice", Role: models.RoleUser, Enabled: true}
 	if err := db.Create(&user).Error; err != nil {
 		t.Fatalf("create user: %v", err)
 	}
 
-	// No recordings dir exists; TtyList should not panic.
+	// No recordings dir exists; List should not panic.
 	// It returns an error (os.Stat fails) but must not panic.
-	_ = TtyList(db, &user, []string{})
+	_ = List(db, &user, []string{})
 }

--- a/internal/commands/tty/play.go
+++ b/internal/commands/tty/play.go
@@ -18,8 +18,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// TtyPlay replays a recorded TTY session.
-func TtyPlay(db *gorm.DB, u *models.User, args []string) error {
+// Play replays a recorded TTY session.
+func Play(db *gorm.DB, u *models.User, args []string) error {
 	fs := flag.NewFlagSet("ttyPlay", flag.ContinueOnError)
 	var username string
 	var file string

--- a/internal/session/modes.go
+++ b/internal/session/modes.go
@@ -129,14 +129,14 @@ func runNonInteractiveMode(db *gorm.DB, currentUser *models.User, log *slog.Logg
 		}
 	} else if strings.HasPrefix(command, "sftp-session") {
 		target := strings.TrimPrefix(strings.TrimPrefix(command, "sftp-session "), "sftp-session")
-		if err := cmdssh.SftpSession(db, *currentUser, *log, target); err != nil {
+		if err := cmdssh.SFTPSession(db, *currentUser, *log, target); err != nil {
 			log.Warn("sftp_session_failed", slog.String("error", err.Error()))
 			fmt.Fprintln(os.Stderr, "SFTP session failed. Check the target host and your access rights.")
 		}
 	} else if isMoshServerRequest(command, args) {
 		runMoshServer(command, args, log)
 	} else {
-		if err := cmdssh.SSHConnect(db, *currentUser, *log, command); err != nil {
+		if err := cmdssh.Connect(db, *currentUser, *log, command); err != nil {
 			fmt.Println(err)
 		}
 	}
@@ -409,7 +409,7 @@ func executeCommand(db *gorm.DB, currentUser *models.User, log *slog.Logger, cmd
 		os.Exit(0)
 		return nil
 	case "ttyPlay":
-		err := cmdtty.TtyPlay(db, currentUser, args)
+		err := cmdtty.Play(db, currentUser, args)
 		resetStdIn()
 		if err != nil {
 			log.Error("command_failed", slog.String("cmd", cmd),

--- a/internal/utils/console/block.go
+++ b/internal/utils/console/block.go
@@ -92,3 +92,39 @@ func DisplayBlock(block ContentBlock) {
 	}
 	fmt.Println(frameColor("╰──────────────────────────────────────────────────────────"))
 }
+
+const (
+	BlockTypeError   = "error"
+	BlockTypeSuccess = "success"
+	BlockTypeWarning = "warning"
+	BlockTypeInfo    = "info"
+	BlockTypeHelp    = "help"
+)
+
+func ErrorBlock(title, subtitle, message string) {
+	DisplayBlock(ContentBlock{
+		Title: title, BlockType: BlockTypeError,
+		Sections: []SectionContent{{SubTitle: subtitle, Body: []string{message}}},
+	})
+}
+
+func SuccessBlock(title, subtitle, message string) {
+	DisplayBlock(ContentBlock{
+		Title: title, BlockType: BlockTypeSuccess,
+		Sections: []SectionContent{{SubTitle: subtitle, Body: []string{message}}},
+	})
+}
+
+func WarningBlock(title, subtitle, message string) {
+	DisplayBlock(ContentBlock{
+		Title: title, BlockType: BlockTypeWarning,
+		Sections: []SectionContent{{SubTitle: subtitle, Body: []string{message}}},
+	})
+}
+
+func InfoBlock(title, subtitle, message string) {
+	DisplayBlock(ContentBlock{
+		Title: title, BlockType: BlockTypeInfo,
+		Sections: []SectionContent{{SubTitle: subtitle, Body: []string{message}}},
+	})
+}

--- a/internal/utils/validation/validation.go
+++ b/internal/utils/validation/validation.go
@@ -7,6 +7,12 @@ import (
 	"strings"
 )
 
+var (
+	AliasRegexp     = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+	GroupNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+	RealmNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+)
+
 // ValidProtocols is the set of accepted protocol values for access entries.
 var ValidProtocols = map[string]bool{
 	"ssh":         true,


### PR DESCRIPTION
- Strip package-name prefix from exported functions across self, group, account, realm, piv, restricted, tty, totp, ssh packages (e.g. self.SelfListAccesses → self.ListAccesses)
- Remove Hungarian Str suffix from local variables (e.g. expiresStr → expires, fromStr → allowedFrom) 
- Fix acronym inconsistency: SftpSession → SFTPSession 
- Rename cmdutil package to cmdhelper