### PR TITLE
fix(security): harden MFA, visibility policies and admin command behavior

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -90,6 +90,7 @@ In **goBastion**, **the database is the single source of truth** for SSH keys an
 | 📋 `pivListTrustAnchors`    | List all registered PIV trust anchor CAs.                                    |
 | ❌ `pivRemoveTrustAnchor`   | Remove a PIV trust anchor CA.                                                |
 | ⚙️ `bastionConfig`         | Interactive configuration manager (view/edit bastion config stored in DB).    |
+| 🔐 `bastionShowSFTPHostKey` | Show the stable public host key used by `sftp-session` for client distribution. |
 
 ---
 
@@ -111,15 +112,15 @@ In **goBastion**, **the database is the single source of truth** for SSH keys an
 
 | Command                     | Description                                       |
 |-----------------------------|---------------------------------------------------|
-| ℹ️ `groupInfo`              | Show detailed information about a group.          |
-| 📋 `groupList`              | List all groups.                                  |
+| ℹ️ `groupInfo`              | Show detailed information about a group (subject to `security.group_visibility.mode`). |
+| 📋 `groupList`              | List groups. `--all` availability depends on `security.group_visibility.mode`. |
 | ➕ `groupCreate`             | Create a new group.                               |
 | ❌ `groupDelete`             | Delete a group.                                   |
 | ➕ `groupAddMember`          | Add a user to a group.                            |
 | ❌ `groupDelMember`          | Remove a user from a group.                       |
 | 🔑 `groupGenerateEgressKey` | Generate a new egress SSH key for the group.      |
-| 🔑 `groupListEgressKeys`    | List all egress SSH keys associated with a group. |
-| 📋 `groupListAccesses`      | List all accesses assigned to a group.            |
+| 🔑 `groupListEgressKeys`    | List group egress SSH public keys (subject to `security.egress_key_visibility.mode`). |
+| 📋 `groupListAccesses`      | List all accesses assigned to a group (subject to `security.group_visibility.mode`). |
 | ➕ `groupAddAccess`          | Grant access to a group (supports protocol restriction and optional `--guest` scope). The optional TCP connectivity check is restricted to private/reserved IP ranges to prevent network scanning. Use `--force` to skip. |
 | ❌ `groupDelAccess`          | Remove access from a group.                       |
 | 🔐 `groupSetMFA`            | Enable or disable JIT MFA requirement for a group (owner/admin only).       |
@@ -128,11 +129,11 @@ In **goBastion**, **the database is the single source of truth** for SSH keys an
 | 📋 `groupListGuestAccesses`| List guest access grants for a user in a group.                              |
 | ➕ `groupAddAlias`           | Add a group SSH alias.                            |
 | ❌ `groupDelAlias`           | Delete a group SSH alias.                         |
-| 📋 `groupListAliases`       | List all group SSH aliases.                       |
-| 📋 `groupListDBAccesses`    | List all database accesses assigned to a group.   |
+| 📋 `groupListAliases`       | List all group SSH aliases (subject to `security.group_visibility.mode`). |
+| 📋 `groupListDBAccesses`    | List all database accesses assigned to a group (subject to `security.group_visibility.mode`). |
 | ➕ `groupAddDBAccess`        | Grant database access to a group.                 |
 | ❌ `groupDelDBAccess`        | Remove database access from a group.              |
-| 📋 `groupListDBAliases`     | List all group database aliases.                  |
+| 📋 `groupListDBAliases`     | List all group database aliases (subject to `security.group_visibility.mode`). |
 | ➕ `groupAddDBAlias`         | Add a group database alias.                       |
 | ❌ `groupDelDBAlias`         | Delete a group database alias.                    |
 | ➕ `groupAddGuestDBAccess`   | Grant guest database access inside a group.       |
@@ -180,6 +181,8 @@ groupDelGuestAccess --group infra --account bob --grant <grant_id>
 ```
 
 > **Key difference from members:** Members can connect to ALL servers in the group. Guests can only connect to servers explicitly listed in their grants.
+>
+> **Visibility note:** listing guest grants is also affected by `security.group_visibility.mode`. Even when the group itself is visible, a guest user may inspect only their own grants.
 
 ---
 
@@ -238,21 +241,65 @@ goBastion supports two passthrough modes depending on whether you need to use th
 
 goBastion acts as a minimal SSH server and connects to the target with its own egress key. **Your local key does not need to be on the target server.**
 
+This mode now uses a **stable per-instance SSH host key** for the fake in-band SFTP server. Administrators should distribute that public key to client teams exactly like any other SSH host key.
+
+##### Admin workflow
+
+1. Display the stable SFTP proxy host key from the bastion:
+
+```sh
+ssh -tp 2222 admin@bastion -- bastionShowSFTPHostKey
+```
+
+2. Copy the displayed public key (or fingerprint) into your internal client documentation / configuration management.
+
+3. Ask client teams to pin that key in `known_hosts` for the **SSH host alias they invoke in their local client config**.
+This is usually the final `Host my-server` alias used with `sftp my-server`, not the bastion hostname inside `ProxyCommand`.
+
+4. If you need to rotate the key, regenerate it explicitly:
+
+```sh
+docker exec -it goBastion /app/goBastion --regenerateSFTPProxyHostKey
+```
+
+After rotation, redistribute the new public key before asking clients to reconnect.
+
+##### Client-side `known_hosts`
+
+If clients run `sftp my-server`, they should usually pin the key under `my-server`:
+
+```known_hosts
+my-server ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...
+```
+
+If they instead connect through another client-side alias, they should pin the key under that alias:
+
+```known_hosts
+my-server-prod ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...
+```
+
+##### Client-side `ssh_config`
+
 ```ssh-config
 Host my-server
     HostName 192.168.1.10
     User myuser
-    ProxyCommand ssh -p 2222 -- bastion_user@bastion "sftp-session myuser@%h:%p"
-    StrictHostKeyChecking no
-    UserKnownHostsFile /dev/null
+    ProxyCommand ssh -p 2222 -- bastion_user@bastion.example.com "sftp-session myuser@%h:%p"
 ```
 
-> `StrictHostKeyChecking no` is required because goBastion generates an ephemeral host key for the fake SSH server on each connection.
+Then use SFTP normally:
 
-Then use sftp normally:
 ```sh
 sftp my-server
 ```
+
+##### Operational notes
+
+- The bastion user in `ProxyCommand` is the **ingress account on goBastion**.
+- The `myuser@%h:%p` part is the **target account on the destination server**.
+- The host key presented by `sftp-session` is verified against the **client-side SSH host alias** being opened by the SFTP client.
+- Because the SFTP proxy host key is now stable, you should **not** use `StrictHostKeyChecking no` or `UserKnownHostsFile /dev/null` anymore.
+- Rotating the SFTP proxy host key invalidates the previously pinned client entry. Treat it like any other SSH host key rotation.
 
 #### Mode 2 — TCP proxy (requires your key on the target)
 
@@ -273,6 +320,10 @@ This enables:
 - `scp file.txt user@my-server:/path/`
 - `sftp user@my-server`
 - `rsync -avz ./dir/ user@my-server:/path/`
+
+Operational notes:
+- This mode requires the client's own SSH key to be trusted directly on the target host.
+- This mode is **not suitable when account-level MFA must prompt interactively**. If password MFA, TOTP MFA, or global `require_mfa` are enabled on the bastion account, prefer `sftp-session`.
 
 All passthrough connections are subject to the same access control rules as interactive SSH sessions.
 
@@ -731,13 +782,13 @@ The following commands require admin or superowner by default, but can be grante
 | `groupDelAlias`          | ✅    | ✅        | ✅         |        |       |
 | `groupAddDBAlias`        | ✅    | ✅        | ✅         |        |       |
 | `groupDelDBAlias`        | ✅    | ✅        | ✅         |        |       |
-| `groupInfo`              | ✅    | ✅        | ✅         | ✅     | ✅    |
-| `groupList`              | ✅    | ✅        | ✅         | ✅     | ✅    |
-| `groupListAccesses`      | ✅    | ✅        | ✅         | ✅     |       |
-| `groupListAliases`       | ✅    | ✅        | ✅         | ✅     |       |
-| `groupListDBAccesses`    | ✅    | ✅        | ✅         | ✅     |       |
-| `groupListDBAliases`     | ✅    | ✅        | ✅         | ✅     |       |
-| `groupListEgressKeys`    | ✅    | ✅        | ✅         | ✅     | ✅    |
+| `groupInfo`              | ✅    | ✅        | ✅         | ✅     | ✅ (`security.group_visibility.mode`) |
+| `groupList`              | ✅    | ✅        | ✅         | ✅     | ✅ (`security.group_visibility.mode`) |
+| `groupListAccesses`      | ✅    | ✅        | ✅         | ✅     | ✅ (`security.group_visibility.mode`) |
+| `groupListAliases`       | ✅    | ✅        | ✅         | ✅     | ✅ (`security.group_visibility.mode`) |
+| `groupListDBAccesses`    | ✅    | ✅        | ✅         | ✅     | ✅ (`security.group_visibility.mode`) |
+| `groupListDBAliases`     | ✅    | ✅        | ✅         | ✅     | ✅ (`security.group_visibility.mode`) |
+| `groupListEgressKeys`    | ✅    | ✅        | ✅         | ✅     | ✅ (`security.egress_key_visibility.mode`) |
 
 ### 👤 **Self Permissions**
 
@@ -970,6 +1021,75 @@ In practice:
 - `max_concurrent_sessions` limits concurrent authenticated sessions on that instance
 - `idle_timeout` and `max_session_duration` accept `0` to disable the limit, or a duration of at least `30s`
 - `ttyrec.retention_days=0` keeps recordings indefinitely
+- group discovery and group egress-key discovery are controlled by `security.group_visibility.mode` and `security.egress_key_visibility.mode`
+
+**Visibility policies:**
+
+```yaml
+security:
+  group_visibility:
+    mode: open
+  egress_key_visibility:
+    mode: discoverable
+```
+
+- `security.group_visibility.mode`
+  - `open`: every authenticated user can use `groupList --all` and `groupInfo` on any group
+  - `members`: only members of a group can view its details and list its shared resources (`groupInfo`, `groupListAccesses`, `groupListAliases`, `groupListDBAccesses`, `groupListDBAliases`); `groupList --all` becomes admin/superowner only
+  - `managers`: only owners, aclkeepers and gatekeepers can view group details and list its shared resources; `groupList --all` becomes admin/superowner only
+  - `private`: only direct group members can view their own groups and list their shared resources; admins and superowners can still view any group; `groupList --all` becomes admin/superowner only
+
+Commands affected by `security.group_visibility.mode`:
+- `groupInfo`
+- `groupList --all`
+- `groupListAccesses`
+- `groupListAliases`
+- `groupListDBAccesses`
+- `groupListDBAliases`
+- `groupListGuestAccesses`
+- `groupListGuestDBAccesses`
+
+- `security.egress_key_visibility.mode`
+  - `discoverable`: any authenticated user can list the public egress keys of a group
+  - `members`: only group members, admins and superowners can list them
+  - `managers`: only owners, aclkeepers, gatekeepers, admins and superowners can list them
+  - `private`: only group owners, admins and superowners can list them
+
+**Examples of operator-facing denial messages:**
+
+- `groupList --all` when global group listing is blocked:
+
+```text
+Access Denied
+- You do not have permission to list all groups under the current visibility policy.
+- Current policy: security.group_visibility.mode=members
+```
+
+- `groupInfo --group infra` when only managers may inspect a group:
+
+```text
+Access Denied
+- You do not have permission to view group 'infra' under the current visibility policy.
+- Current policy: security.group_visibility.mode=managers
+- Required: owner, aclkeeper, gatekeeper, admin, or superowner in the target group.
+```
+
+- `groupListEgressKeys --group infra` when egress keys are private:
+
+```text
+Access Denied
+- You do not have permission to list egress keys for group 'infra'.
+- Current policy: security.egress_key_visibility.mode=private
+- Required: group owner, admin, or superowner.
+```
+
+- `groupListGuestAccesses --group infra --account bob` as a guest user inspecting another account:
+
+```text
+Access Denied
+- Guest users can only view their own grants in this group.
+- Requested account: bob
+```
 
 **How it works:**
 1. At startup, goBastion reads `DB_DRIVER`, `DB_DSN`, and `INSTANCE_ID` from environment variables.
@@ -1014,10 +1134,11 @@ These flags are only available when running as `root` outside an SSH session:
 |------|---------|----------------------------------------------------------------------------------------------------------|
 | `--firstInstall` | `docker exec -it goBastion /app/goBastion --firstInstall` | Manually bootstrap the first admin user (interactive)                                                    |
 | `--regenerateSSHHostKeys` | `docker exec -it goBastion /app/goBastion --regenerateSSHHostKeys` | Force-regenerate the bastion's SSH host keys                                                             |
+| `--regenerateSFTPProxyHostKey` | `docker exec -it goBastion /app/goBastion --regenerateSFTPProxyHostKey` | Force-regenerate the stable host key presented to `sftp-session` clients                                 |
 | `--sync` | `docker exec goBastion /app/goBastion --sync` | Enforce DB state onto the OS immediately (DB is source of truth); also runs automatically every 5 minutes |
 | `--dbExport` | `docker exec -i -e DB_EXPORT_KEY="$DB_EXPORT_KEY" goBastion /app/goBastion --dbExport > dump` | Dump the database as encrypted file to stdout                                                            |
 | `--dbImport` | `docker exec -i -e DB_EXPORT_KEY="$DB_EXPORT_KEY" goBastion /app/goBastion --dbImport < dump` | Restore the database from encrypted file on stdin                                                        |
-| `--disableTOTP` | `docker exec -it goBastion /app/goBastion --disableTOTP <user>` | Disable TOTP, password MFA, and backup codes for a user (recovery)                                       |
+| `--disableTOTP` | `docker exec -it goBastion /app/goBastion --disableTOTP <user>` | Disable TOTP and backup codes for a user (recovery)                                                      |
 
 ### 🔐 Database Export / Import
 

--- a/cmd/goBastion/main.go
+++ b/cmd/goBastion/main.go
@@ -41,6 +41,14 @@ func hasArg(name string) bool {
 	return false
 }
 
+func shouldRunMigrate() bool {
+	return os.Getuid() == 0 && !hasArg("--sync") && !hasArg("--syncUser")
+}
+
+func shouldBootstrapInstanceConfig() bool {
+	return !hasArg("--dbImport")
+}
+
 func main() {
 	tStart := time.Now()
 
@@ -58,7 +66,7 @@ func main() {
 	// Only root (master process) runs schema migration; ForceCommand sessions
 	// and --sync invocations connect to the same DB but skip the expensive
 	// AutoMigrate — the master process already ran it at startup.
-	runMigrate := os.Getuid() == 0 && !hasArg("--sync") && !hasArg("--syncUser")
+	runMigrate := shouldRunMigrate()
 	db, err := internalDB.Init(log, runMigrate)
 	if err != nil {
 		log.Error("Failed to initialize database",
@@ -71,22 +79,24 @@ func main() {
 	// Phase 3: Check whether this instance's config row is present, then load
 	// it. Only create the row (EnsureInstance) if it is missing — never the
 	// other way around.
-	tCfg := time.Now()
-	if err := config.LoadFromDB(db); err != nil {
-		if !errors.Is(err, gorm.ErrRecordNotFound) {
-			log.Error("config_load_from_db_failed", slog.Any("error", err))
-			os.Exit(1)
-		}
-		if err := config.EnsureInstance(db); err != nil {
-			log.Error("config_ensure_instance_failed", slog.Any("error", err))
-			os.Exit(1)
-		}
+	if shouldBootstrapInstanceConfig() {
+		tCfg := time.Now()
 		if err := config.LoadFromDB(db); err != nil {
-			log.Error("config_load_from_db_failed", slog.Any("error", err))
-			os.Exit(1)
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				log.Error("config_load_from_db_failed", slog.Any("error", err))
+				os.Exit(1)
+			}
+			if err := config.EnsureInstance(db); err != nil {
+				log.Error("config_ensure_instance_failed", slog.Any("error", err))
+				os.Exit(1)
+			}
+			if err := config.LoadFromDB(db); err != nil {
+				log.Error("config_load_from_db_failed", slog.Any("error", err))
+				os.Exit(1)
+			}
 		}
+		log.Info("config_loaded", slog.Duration("took", time.Since(tCfg)))
 	}
-	log.Info("config_loaded", slog.Duration("took", time.Since(tCfg)))
 
 	adapter := osadapter.NewLinuxAdapter()
 

--- a/cmd/goBastion/main_test.go
+++ b/cmd/goBastion/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestShouldBootstrapInstanceConfig(t *testing.T) {
+	origArgs := os.Args
+	t.Cleanup(func() { os.Args = origArgs })
+
+	os.Args = []string{"goBastion"}
+	if !shouldBootstrapInstanceConfig() {
+		t.Fatal("expected bootstrap config on normal startup")
+	}
+
+	os.Args = []string{"goBastion", "--dbImport"}
+	if shouldBootstrapInstanceConfig() {
+		t.Fatal("expected bootstrap config to be skipped for --dbImport")
+	}
+}

--- a/internal/commands/account/add_access.go
+++ b/internal/commands/account/add_access.go
@@ -46,7 +46,7 @@ func AddAccess(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Usage", Body: []string{"Usage: accountAddAccess --user <username> --server <host> --username <user> --port <port> [--comment <comment>] [--from <CIDRs>] [--ttl <days>] [--protocol ssh|scpupload|scpdownload|sftp|rsync]"}}},
 		})
-		return nil
+		return fmt.Errorf("missing required arguments")
 	}
 
 	if !currentUser.CanDo(db, "accountAddAccess", targetUser) {
@@ -55,7 +55,7 @@ func AddAccess(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: []string{"You do not have permission to add personal access for this user."}}},
 		})
-		return nil
+		return fmt.Errorf("access denied for %s", currentUser.Username)
 	}
 
 	if !validation.IsValidProtocol(protocol) {
@@ -64,7 +64,7 @@ func AddAccess(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Invalid Protocol", Body: []string{"Protocol must be one of: ssh, scpupload, scpdownload, sftp, rsync"}}},
 		})
-		return nil
+		return fmt.Errorf("invalid protocol: %s", protocol)
 	}
 	if !validation.IsValidPort(port) {
 		console.DisplayBlock(console.ContentBlock{
@@ -72,7 +72,7 @@ func AddAccess(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Invalid Port", Body: []string{"Port must be between 1 and 65535"}}},
 		})
-		return nil
+		return fmt.Errorf("invalid port: %d", port)
 	}
 	if !validation.IsValidCIDRs(allowedFrom) {
 		console.DisplayBlock(console.ContentBlock{
@@ -80,7 +80,7 @@ func AddAccess(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Invalid CIDRs", Body: []string{"--from must be a comma-separated list of valid CIDR notation (e.g. 10.0.0.0/8,192.168.1.0/24)"}}},
 		})
-		return nil
+		return fmt.Errorf("invalid CIDRs: %s", allowedFrom)
 	}
 
 	var user models.User

--- a/internal/commands/account/add_access_test.go
+++ b/internal/commands/account/add_access_test.go
@@ -34,11 +34,14 @@ func TestAddAccess_MissingServer(t *testing.T) {
 	newRegularUser(t, db, "alice")
 
 	// Missing --server; should not panic, should not create DB entry
-	_ = AddAccess(db, admin, []string{
+	err := AddAccess(db, admin, []string{
 		"--user", "alice",
 		"--username", "root",
 		"--port", "22",
 	})
+	if err == nil {
+		t.Fatal("expected missing required arguments error")
+	}
 
 	var count int64
 	db.Model(&models.SelfAccess{}).Count(&count)

--- a/internal/commands/account/create.go
+++ b/internal/commands/account/create.go
@@ -37,7 +37,10 @@ func Create(db *gorm.DB, adapter osadapter.SystemAdapter, currentUser *models.Us
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Usage", Body: []string{"Usage: accountCreate --user <username> [--osh-only] [--superowner]"}}},
 		})
-		return err
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("missing required arguments")
 	}
 
 	if !currentUser.CanDo(db, "accountCreate", username) {
@@ -46,7 +49,7 @@ func Create(db *gorm.DB, adapter osadapter.SystemAdapter, currentUser *models.Us
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: []string{"You do not have permission to create an account."}}},
 		})
-		return nil
+		return fmt.Errorf("access denied for %s", currentUser.Username)
 	}
 
 	reader := bufio.NewReader(os.Stdin)

--- a/internal/commands/account/create_test.go
+++ b/internal/commands/account/create_test.go
@@ -79,6 +79,7 @@ func TestCreate_MissingArgs(t *testing.T) {
 	db := newTestDB(t)
 	mock := osadapter.NewMockAdapter()
 	admin := newAdminUser(t, db, "admin")
-	// Should not panic; missing --user arg
-	_ = Create(db, mock, admin, []string{})
+	if err := Create(db, mock, admin, []string{}); err == nil {
+		t.Fatal("expected missing required arguments error")
+	}
 }

--- a/internal/commands/account/delete.go
+++ b/internal/commands/account/delete.go
@@ -36,7 +36,7 @@ func Delete(db *gorm.DB, adapter osadapter.SystemAdapter, currentUser *models.Us
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: []string{"You do not have permission to delete this account."}}},
 		})
-		return nil
+		return fmt.Errorf("access denied for %s", currentUser.Username)
 	}
 
 	if err := DeleteUser(db, adapter, username); err != nil {

--- a/internal/commands/account/expire.go
+++ b/internal/commands/account/expire.go
@@ -37,7 +37,7 @@ func Expire(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Usage", Body: []string{"Usage: accountExpire --user <username>"}}},
 		})
-		return nil
+		return fmt.Errorf("missing required arguments")
 	}
 
 	if !currentUser.CanDo(db, "accountExpire", username) {
@@ -46,7 +46,7 @@ func Expire(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: []string{"You do not have permission to lock this account."}}},
 		})
-		return nil
+		return fmt.Errorf("access denied for %s", currentUser.Username)
 	}
 
 	var u models.User
@@ -65,7 +65,7 @@ func Expire(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "warning",
 			Sections:  []console.SectionContent{{SubTitle: "Already Locked", Body: []string{fmt.Sprintf("User '%s' is already disabled.", username)}}},
 		})
-		return nil
+		return fmt.Errorf("user %q is already disabled", username)
 	}
 
 	// Prevent admins from locking themselves out.
@@ -75,7 +75,7 @@ func Expire(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Blocked", Body: []string{"You cannot lock your own account."}}},
 		})
-		return nil
+		return fmt.Errorf("cannot lock your own account")
 	}
 
 	// Prevent locking the last remaining admin.
@@ -95,7 +95,7 @@ func Expire(db *gorm.DB, currentUser *models.User, args []string) error {
 				BlockType: "error",
 				Sections:  []console.SectionContent{{SubTitle: "Blocked", Body: []string{"Cannot lock the last remaining admin account."}}},
 			})
-			return nil
+			return fmt.Errorf("cannot lock the last remaining admin account")
 		}
 	}
 

--- a/internal/commands/account/expire_test.go
+++ b/internal/commands/account/expire_test.go
@@ -1,0 +1,36 @@
+package account
+
+import "testing"
+
+func TestExpire_MissingArgsReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	admin := newAdminUser(t, db, "admin")
+
+	if err := Expire(db, admin, []string{}); err == nil {
+		t.Fatal("expected missing required arguments error")
+	}
+}
+
+func TestExpire_SelfLockReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	admin := newAdminUser(t, db, "admin")
+
+	err := Expire(db, admin, []string{"--user", "admin"})
+	if err == nil {
+		t.Fatal("expected self-lock error")
+	}
+}
+
+func TestExpire_LastAdminReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	admin := newAdminUser(t, db, "admin")
+	target := newAdminUser(t, db, "other-admin")
+	if err := db.Delete(target).Error; err != nil {
+		t.Fatalf("delete second admin: %v", err)
+	}
+
+	err := Expire(db, admin, []string{"--user", "admin"})
+	if err == nil {
+		t.Fatal("expected last-admin protection error")
+	}
+}

--- a/internal/commands/account/modify.go
+++ b/internal/commands/account/modify.go
@@ -40,7 +40,7 @@ func Modify(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Usage", Body: []string{"Usage: accountModify --user <username> [--sysrole <admin|user>] [--oshOnly <true|false>] [--superOwner <true|false>]"}}},
 		})
-		return nil
+		return fmt.Errorf("missing required arguments")
 	}
 
 	if !currentUser.CanDo(db, "accountModify", username) {
@@ -49,7 +49,7 @@ func Modify(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: []string{"You do not have permission to modify this account."}}},
 		})
-		return nil
+		return fmt.Errorf("access denied for %s", currentUser.Username)
 	}
 
 	newRole = strings.ToLower(strings.TrimSpace(newRole))
@@ -59,7 +59,7 @@ func Modify(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Invalid System Role", Body: []string{"System role must be 'admin' or 'user'."}}},
 		})
-		return nil
+		return fmt.Errorf("invalid system role: %s", newRole)
 	}
 
 	var u models.User
@@ -100,7 +100,7 @@ func Modify(db *gorm.DB, currentUser *models.User, args []string) error {
 				BlockType: "error",
 				Sections:  []console.SectionContent{{SubTitle: "Invalid oshOnly", Body: []string{"--oshOnly must be true or false"}}},
 			})
-			return nil
+			return err
 		}
 		u.OSHOnly = v
 	}
@@ -112,7 +112,7 @@ func Modify(db *gorm.DB, currentUser *models.User, args []string) error {
 				BlockType: "error",
 				Sections:  []console.SectionContent{{SubTitle: "Invalid superOwner", Body: []string{"--superOwner must be true or false"}}},
 			})
-			return nil
+			return err
 		}
 		u.SuperOwner = v
 	}

--- a/internal/commands/account/modify_test.go
+++ b/internal/commands/account/modify_test.go
@@ -1,0 +1,40 @@
+package account
+
+import "testing"
+
+func TestModify_MissingArgsReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	admin := newAdminUser(t, db, "admin")
+
+	if err := Modify(db, admin, []string{"--user", "alice"}); err == nil {
+		t.Fatal("expected missing required arguments error")
+	}
+}
+
+func TestModify_InvalidRoleReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	admin := newAdminUser(t, db, "admin")
+	newRegularUser(t, db, "alice")
+
+	err := Modify(db, admin, []string{
+		"--user", "alice",
+		"--sysrole", "invalid",
+	})
+	if err == nil {
+		t.Fatal("expected invalid role error")
+	}
+}
+
+func TestModify_InvalidBoolReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	admin := newAdminUser(t, db, "admin")
+	newRegularUser(t, db, "alice")
+
+	err := Modify(db, admin, []string{
+		"--user", "alice",
+		"--oshOnly", "maybe",
+	})
+	if err == nil {
+		t.Fatal("expected invalid boolean error")
+	}
+}

--- a/internal/commands/account/set_password.go
+++ b/internal/commands/account/set_password.go
@@ -30,7 +30,10 @@ func SetPassword(db *gorm.DB, currentUser *models.User, log *slog.Logger, args [
 			Title: "Set Account Password MFA", BlockType: "error",
 			Sections: []console.SectionContent{{SubTitle: "Usage", Body: []string{"accountSetPassword --user <username> [--clear]"}}},
 		})
-		return nil
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("missing required arguments")
 	}
 
 	if !currentUser.CanDo(db, "accountSetPassword", targetUser) {
@@ -38,7 +41,7 @@ func SetPassword(db *gorm.DB, currentUser *models.User, log *slog.Logger, args [
 			Title: "Set Account Password MFA", BlockType: "error",
 			Sections: []console.SectionContent{{SubTitle: "Access Denied", Body: []string{"Only admins can set password MFA for other users."}}},
 		})
-		return nil
+		return fmt.Errorf("access denied for %s", currentUser.Username)
 	}
 
 	var user models.User
@@ -77,7 +80,7 @@ func SetPassword(db *gorm.DB, currentUser *models.User, log *slog.Logger, args [
 			Title: "Set Account Password MFA", BlockType: "error",
 			Sections: []console.SectionContent{{SubTitle: "Error", Body: []string{"Password must be at least 8 characters."}}},
 		})
-		return nil
+		return fmt.Errorf("password must be at least 8 characters")
 	}
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {

--- a/internal/commands/account/set_password_test.go
+++ b/internal/commands/account/set_password_test.go
@@ -1,0 +1,15 @@
+package account
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func TestSetPassword_MissingArgsReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	admin := newAdminUser(t, db, "admin")
+
+	if err := SetPassword(db, admin, slog.Default(), nil); err == nil {
+		t.Fatal("expected missing required arguments error")
+	}
+}

--- a/internal/commands/account/unexpire.go
+++ b/internal/commands/account/unexpire.go
@@ -36,7 +36,7 @@ func Unexpire(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Usage", Body: []string{"Usage: accountUnexpire --user <username>"}}},
 		})
-		return nil
+		return fmt.Errorf("missing required arguments")
 	}
 
 	if !currentUser.CanDo(db, "accountUnexpire", username) {
@@ -45,7 +45,7 @@ func Unexpire(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: []string{"You do not have permission to re-enable this account."}}},
 		})
-		return nil
+		return fmt.Errorf("access denied for %s", currentUser.Username)
 	}
 
 	var u models.User
@@ -64,12 +64,12 @@ func Unexpire(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "warning",
 			Sections:  []console.SectionContent{{SubTitle: "Already Active", Body: []string{fmt.Sprintf("User '%s' is already enabled.", username)}}},
 		})
-		return nil
+		return fmt.Errorf("user %q is already enabled", username)
 	}
 
 	if err := db.Model(&u).Updates(map[string]any{
-		"enabled":        true,
-		"last_login_at":  time.Time{},
+		"enabled":         true,
+		"last_login_at":   time.Time{},
 		"last_login_from": "",
 	}).Error; err != nil {
 		console.DisplayBlock(console.ContentBlock{

--- a/internal/commands/account/unexpire_test.go
+++ b/internal/commands/account/unexpire_test.go
@@ -1,0 +1,23 @@
+package account
+
+import "testing"
+
+func TestUnexpire_MissingArgsReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	admin := newAdminUser(t, db, "admin")
+
+	if err := Unexpire(db, admin, []string{}); err == nil {
+		t.Fatal("expected missing required arguments error")
+	}
+}
+
+func TestUnexpire_AlreadyEnabledReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	admin := newAdminUser(t, db, "admin")
+	newRegularUser(t, db, "alice")
+
+	err := Unexpire(db, admin, []string{"--user", "alice"})
+	if err == nil {
+		t.Fatal("expected already enabled error")
+	}
+}

--- a/internal/commands/config/bastion_config.go
+++ b/internal/commands/config/bastion_config.go
@@ -752,12 +752,6 @@ func applyValue(db *gorm.DB, key, newValue string) error {
 		raw[section] = sec
 	}
 
-	current := sec[field]
-	coerced, err := coerceValue(fmt.Sprintf("%v", current), newValue)
-	if err != nil {
-		return fmt.Errorf("invalid value: %v", err)
-	}
-
 	// Guard: session time limits must be at least 30s (0 disables/unlimits them).
 	switch key {
 	case "session.idle_timeout":
@@ -772,9 +766,29 @@ func applyValue(db *gorm.DB, key, newValue string) error {
 		if n, perr := strconv.ParseInt(strings.TrimSpace(newValue), 10, 64); perr == nil && n < 0 {
 			return fmt.Errorf("retention_days must be 0 or greater (use 0 to keep forever)")
 		}
+	case "security.group_visibility.mode":
+		switch strings.ToLower(strings.TrimSpace(newValue)) {
+		case "open", "members", "managers", "private":
+		default:
+			return fmt.Errorf("group_visibility.mode must be one of: open, members, managers, private")
+		}
+	case "security.egress_key_visibility.mode":
+		switch strings.ToLower(strings.TrimSpace(newValue)) {
+		case "discoverable", "members", "managers", "private":
+		default:
+			return fmt.Errorf("egress_key_visibility.mode must be one of: discoverable, members, managers, private")
+		}
 	}
 
-	sec[field] = coerced
+	current, parent, leaf, err := resolveConfigLeaf(sec, field)
+	if err != nil {
+		return err
+	}
+	coerced, err := coerceValue(fmt.Sprintf("%v", current), newValue)
+	if err != nil {
+		return fmt.Errorf("invalid value: %v", err)
+	}
+	parent[leaf] = coerced
 
 	patchedJSON, err := json.MarshalIndent(raw, "", "  ")
 	if err != nil {
@@ -791,6 +805,23 @@ func applyValue(db *gorm.DB, key, newValue string) error {
 	patchedCfg.InternalDB.DSN = cfg.InternalDB.DSN
 
 	return config.SaveConfig(db, patchedCfg)
+}
+
+func resolveConfigLeaf(section map[string]any, field string) (current any, parent map[string]any, leaf string, err error) {
+	parts := strings.Split(field, ".")
+	parent = section
+	for i := 0; i < len(parts)-1; i++ {
+		part := parts[i]
+		next, ok := parent[part].(map[string]any)
+		if !ok {
+			next = map[string]any{}
+			parent[part] = next
+		}
+		parent = next
+	}
+	leaf = parts[len(parts)-1]
+	current = parent[leaf]
+	return current, parent, leaf, nil
 }
 
 // parseDurationInput parses a duration with the same rules as the config

--- a/internal/commands/config/bastion_config_test.go
+++ b/internal/commands/config/bastion_config_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"testing"
+
+	appconfig "goBastion/internal/config"
+	"goBastion/internal/models"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestApplyValueUpdatesNestedVisibilityConfig(t *testing.T) {
+	appconfig.ResetForTesting()
+	cfg := appconfig.DefaultConfig()
+	appconfig.SetForTesting(cfg)
+	defer appconfig.ResetForTesting()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test DB: %v", err)
+	}
+	if err := db.AutoMigrate(&models.BastionInstance{}); err != nil {
+		t.Fatalf("migrate bastion_instances: %v", err)
+	}
+
+	boot := &appconfig.Bootstrap{InstanceID: "test-instance"}
+	t.Setenv("INSTANCE_ID", "test-instance")
+	appconfig.Load()
+	if err := appconfig.EnsureInstance(db); err != nil {
+		t.Fatalf("ensure instance: %v", err)
+	}
+	_ = boot
+
+	if err := applyValue(db, "security.group_visibility.mode", "members"); err != nil {
+		t.Fatalf("applyValue group visibility: %v", err)
+	}
+	if err := appconfig.LoadFromDB(db); err != nil {
+		t.Fatalf("reload config from DB: %v", err)
+	}
+	if got := appconfig.Get().Security.GroupVisibility.Mode; got != "members" {
+		t.Fatalf("group visibility mode = %q, want members", got)
+	}
+
+	if err := applyValue(db, "security.egress_key_visibility.mode", "private"); err != nil {
+		t.Fatalf("applyValue egress key visibility: %v", err)
+	}
+	if err := appconfig.LoadFromDB(db); err != nil {
+		t.Fatalf("reload config from DB: %v", err)
+	}
+	if got := appconfig.Get().Security.EgressKeyVisibility.Mode; got != "private" {
+		t.Fatalf("egress key visibility mode = %q, want private", got)
+	}
+}

--- a/internal/commands/config/sftp_proxy_host_key.go
+++ b/internal/commands/config/sftp_proxy_host_key.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"fmt"
+
+	"goBastion/internal/models"
+	"goBastion/internal/utils/console"
+	"goBastion/internal/utils/sshHostKey"
+
+	"gorm.io/gorm"
+)
+
+// ShowSFTPProxyHostKey displays the stable host key used by sftp-session so
+// administrators can distribute it to client teams.
+func ShowSFTPProxyHostKey(db *gorm.DB, currentUser *models.User) error {
+	if !currentUser.CanDo(db, "bastionConfig", "") {
+		console.DisplayBlock(console.ContentBlock{
+			Title:     "SFTP Proxy Host Key",
+			BlockType: "error",
+			Sections: []console.SectionContent{
+				{SubTitle: "Access Denied", Body: []string{"You do not have permission to view the SFTP proxy host key."}},
+			},
+		})
+		return nil
+	}
+
+	_, publicKey, fingerprint, err := sshHostKey.EnsureSFTPProxyHostKey(db, false)
+	if err != nil {
+		return fmt.Errorf("load SFTP proxy host key: %w", err)
+	}
+
+	console.DisplayBlock(console.ContentBlock{
+		Title:     "SFTP Proxy Host Key",
+		BlockType: "info",
+		Sections: []console.SectionContent{
+			{SubTitle: "Fingerprint", Body: []string{fingerprint}},
+			{SubTitle: "Public Key", Body: []string{publicKey}},
+			{SubTitle: "Admin Workflow", Body: []string{
+				"Distribute this public key to client teams using sftp-session.",
+				"Each client must pin it in known_hosts for the final SSH host alias they use with sftp, not the bastion hostname inside ProxyCommand.",
+				"Rotate it with: /app/goBastion --regenerateSFTPProxyHostKey",
+			}},
+		},
+	})
+	return nil
+}

--- a/internal/commands/group/add_access.go
+++ b/internal/commands/group/add_access.go
@@ -2,6 +2,7 @@ package group
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"net"
@@ -150,10 +151,17 @@ func AddAccess(db *gorm.DB, currentUser *models.User, args []string) error {
 	if err := db.Where("group_id = ? AND server = ? AND port = ? AND username = ?", group.ID, server, port, username).First(&existingAccess).Error; err == nil {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Add Group Access",
-			BlockType: "info",
-			Sections:  []console.SectionContent{{SubTitle: "Info", Body: []string{"Access already exists for this group with the given server, port, and username."}}},
+			BlockType: "error",
+			Sections:  []console.SectionContent{{SubTitle: "Error", Body: []string{"Access already exists for this group with the given server, port, and username."}}},
 		})
-		return nil
+		return fmt.Errorf("group access already exists for %s@%s:%d in group %q", username, server, port, groupName)
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		console.DisplayBlock(console.ContentBlock{
+			Title:     "Add Group Access",
+			BlockType: "error",
+			Sections:  []console.SectionContent{{SubTitle: "Database Error", Body: []string{"Database error while checking for existing access. Please try again."}}},
+		})
+		return fmt.Errorf("database error: %v", err)
 	}
 
 	access := models.GroupAccess{
@@ -185,4 +193,3 @@ func AddAccess(db *gorm.DB, currentUser *models.User, args []string) error {
 	})
 	return nil
 }
-

--- a/internal/commands/group/add_access_test.go
+++ b/internal/commands/group/add_access_test.go
@@ -32,3 +32,34 @@ func TestAddAccess_Success(t *testing.T) {
 		t.Fatalf("expected 1 group access entry, got %d", count)
 	}
 }
+
+func TestAddAccess_DuplicateReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	admin := newAdminUser(t, db, "admin")
+
+	g := models.Group{Name: "mygroup"}
+	if err := db.Create(&g).Error; err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+
+	if err := AddAccess(db, admin, []string{
+		"--group", "mygroup",
+		"--server", "10.0.0.1",
+		"--username", "deploy",
+		"--port", "22",
+		"--force",
+	}); err != nil {
+		t.Fatalf("seed group access: %v", err)
+	}
+
+	err := AddAccess(db, admin, []string{
+		"--group", "mygroup",
+		"--server", "10.0.0.1",
+		"--username", "deploy",
+		"--port", "22",
+		"--force",
+	})
+	if err == nil {
+		t.Fatal("expected duplicate group access error")
+	}
+}

--- a/internal/commands/group/add_db_access.go
+++ b/internal/commands/group/add_db_access.go
@@ -128,10 +128,10 @@ func AddDBAccess(db *gorm.DB, currentUser *models.User, args []string) error {
 	if err := db.Where("group_id = ? AND host = ? AND port = ? AND protocol = ?", group.ID, host, port, protocol).First(&existingAccess).Error; err == nil {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Add Group DB Access",
-			BlockType: "info",
-			Sections:  []console.SectionContent{{SubTitle: "Info", Body: []string{"Access already exists for this group with the given host, port, and protocol."}}},
+			BlockType: "error",
+			Sections:  []console.SectionContent{{SubTitle: "Error", Body: []string{"Access already exists for this group with the given host, port, and protocol."}}},
 		})
-		return nil
+		return fmt.Errorf("group DB access already exists for %s:%d/%s in group %q", host, port, protocol, groupName)
 	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Add Group DB Access",

--- a/internal/commands/group/add_db_alias.go
+++ b/internal/commands/group/add_db_alias.go
@@ -32,7 +32,10 @@ func AddDBAlias(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Usage", Body: []string{"Usage: groupAddDBAlias --group <group_name> --alias <alias> --host <host> --port <port> --protocol <protocol>"}}},
 		})
-		return err
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("missing required arguments")
 	}
 
 	if !currentUser.CanDo(db, "groupAddDBAlias", groupName) {
@@ -60,7 +63,7 @@ func AddDBAlias(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Invalid Protocol", Body: []string{"Protocol contains invalid characters."}}},
 		})
-		return nil
+		return fmt.Errorf("invalid protocol: %s", protocol)
 	}
 	var existing models.DatabaseAlias
 	if err := db.Where("LOWER(resolve_from) = ? AND group_id = ? AND deleted_at IS NULL", strings.ToLower(alias), group.ID).First(&existing).Error; err == nil {
@@ -69,7 +72,7 @@ func AddDBAlias(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Duplicate", Body: []string{"An alias with this name already exists for this group."}}},
 		})
-		return nil
+		return fmt.Errorf("group DB alias %q already exists in group %q", alias, groupName)
 	}
 
 	newAlias := models.DatabaseAlias{

--- a/internal/commands/group/add_db_alias_test.go
+++ b/internal/commands/group/add_db_alias_test.go
@@ -19,8 +19,8 @@ func TestAddDBAliasRejectsCaseInsensitiveDuplicateInGroupScope(t *testing.T) {
 		t.Fatalf("seed db alias: %v", err)
 	}
 
-	if err := AddDBAlias(db, admin, []string{"--group", "infra", "--alias", "proddb", "--host", "db2", "--port", "5432", "--protocol", "postgres"}); err != nil {
-		t.Fatalf("AddDBAlias returned error: %v", err)
+	if err := AddDBAlias(db, admin, []string{"--group", "infra", "--alias", "proddb", "--host", "db2", "--port", "5432", "--protocol", "postgres"}); err == nil {
+		t.Fatal("expected duplicate group db alias error")
 	}
 
 	var count int64

--- a/internal/commands/group/add_guest_access.go
+++ b/internal/commands/group/add_guest_access.go
@@ -43,7 +43,10 @@ func AddGuestAccess(db *gorm.DB, currentUser *models.User, args []string) error 
 				"Usage: groupAddGuestAccess --group <group> --account <user> --host <server> --user <remote_user> [--port <port>] [--protocol <proto>] [--ttl <days>] [--comment <text>] [--from <CIDRs>]",
 			}}},
 		})
-		return err
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("missing required arguments")
 	}
 
 	if !currentUser.CanDo(db, "groupAddGuestAccess", groupName) {
@@ -61,7 +64,7 @@ func AddGuestAccess(db *gorm.DB, currentUser *models.User, args []string) error 
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Invalid Server", Body: []string{"Server hostname/IP contains invalid characters."}}},
 		})
-		return nil
+		return fmt.Errorf("invalid server: %s", server)
 	}
 	if !validation.IsValidPort(port) {
 		console.DisplayBlock(console.ContentBlock{
@@ -69,7 +72,7 @@ func AddGuestAccess(db *gorm.DB, currentUser *models.User, args []string) error 
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Invalid Port", Body: []string{"Port must be between 1 and 65535"}}},
 		})
-		return nil
+		return fmt.Errorf("invalid port: %d", port)
 	}
 	if !validation.IsValidProtocol(protocol) {
 		console.DisplayBlock(console.ContentBlock{
@@ -77,7 +80,7 @@ func AddGuestAccess(db *gorm.DB, currentUser *models.User, args []string) error 
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Invalid Protocol", Body: []string{"Protocol must be one of: ssh, scpupload, scpdownload, sftp, rsync"}}},
 		})
-		return nil
+		return fmt.Errorf("invalid protocol: %s", protocol)
 	}
 	if !validation.IsValidCIDRs(allowedFrom) {
 		console.DisplayBlock(console.ContentBlock{
@@ -85,7 +88,7 @@ func AddGuestAccess(db *gorm.DB, currentUser *models.User, args []string) error 
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Invalid CIDRs", Body: []string{"--from must be a comma-separated list of valid CIDRs"}}},
 		})
-		return nil
+		return fmt.Errorf("invalid CIDRs: %s", allowedFrom)
 	}
 	if ttlDays < 0 {
 		console.DisplayBlock(console.ContentBlock{
@@ -93,7 +96,7 @@ func AddGuestAccess(db *gorm.DB, currentUser *models.User, args []string) error 
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Invalid TTL", Body: []string{"TTL must be zero (never) or positive"}}},
 		})
-		return nil
+		return fmt.Errorf("invalid TTL: %d", ttlDays)
 	}
 
 	// TCP connectivity check (private targets only).
@@ -150,7 +153,7 @@ func AddGuestAccess(db *gorm.DB, currentUser *models.User, args []string) error 
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Wrong Role", Body: []string{fmt.Sprintf("User '%s' has role '%s' in group '%s', not 'guest'. Guest access grants only apply to guest-role users.", account, ug.Role, groupName)}}},
 		})
-		return nil
+		return fmt.Errorf("user %q has role %q in group %q, expected guest", account, ug.Role, groupName)
 	}
 
 	// Check for duplicate.
@@ -159,10 +162,10 @@ func AddGuestAccess(db *gorm.DB, currentUser *models.User, args []string) error 
 		group.ID, targetUser.ID, server, port, remoteUser).First(&existing).Error; err == nil {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Add Guest Access",
-			BlockType: "info",
-			Sections:  []console.SectionContent{{SubTitle: "Already Exists", Body: []string{"This guest access grant already exists."}}},
+			BlockType: "error",
+			Sections:  []console.SectionContent{{SubTitle: "Error", Body: []string{"This guest access grant already exists."}}},
 		})
-		return nil
+		return fmt.Errorf("guest access already exists for %s -> %s@%s:%d in group %q", account, remoteUser, server, port, groupName)
 	}
 
 	guestAccess := models.GroupGuestAccess{

--- a/internal/commands/group/add_guest_access_test.go
+++ b/internal/commands/group/add_guest_access_test.go
@@ -1,0 +1,67 @@
+package group
+
+import (
+	"testing"
+
+	"goBastion/internal/models"
+)
+
+func TestAddGuestAccess_WrongRoleReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	admin := newAdminUser(t, db, "admin")
+	alice := newRegularUser(t, db, "alice")
+
+	group := models.Group{Name: "mygroup"}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	if err := db.Create(&models.UserGroup{UserID: alice.ID, GroupID: group.ID, Role: models.GroupRoleMember}).Error; err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+
+	err := AddGuestAccess(db, admin, []string{
+		"--group", "mygroup",
+		"--account", "alice",
+		"--host", "10.0.0.2",
+		"--user", "deploy",
+		"--port", "22",
+	})
+	if err == nil {
+		t.Fatal("expected wrong role error")
+	}
+}
+
+func TestAddGuestAccess_DuplicateReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	admin := newAdminUser(t, db, "admin")
+	alice := newRegularUser(t, db, "alice")
+
+	group := models.Group{Name: "mygroup"}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	if err := db.Create(&models.UserGroup{UserID: alice.ID, GroupID: group.ID, Role: models.GroupRoleGuest}).Error; err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+	if err := db.Create(&models.GroupGuestAccess{
+		GroupID:  group.ID,
+		UserID:   alice.ID,
+		Server:   "10.0.0.2",
+		Port:     22,
+		Username: "deploy",
+		Protocol: "ssh",
+	}).Error; err != nil {
+		t.Fatalf("seed guest access: %v", err)
+	}
+
+	err := AddGuestAccess(db, admin, []string{
+		"--group", "mygroup",
+		"--account", "alice",
+		"--host", "10.0.0.2",
+		"--user", "deploy",
+		"--port", "22",
+	})
+	if err == nil {
+		t.Fatal("expected duplicate guest access error")
+	}
+}

--- a/internal/commands/group/add_member.go
+++ b/internal/commands/group/add_member.go
@@ -67,7 +67,7 @@ func AddMember(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Already Exists", Body: []string{fmt.Sprintf("User '%s' is already in group '%s'.", username, groupName)}}},
 		})
-		return nil
+		return fmt.Errorf("user %q is already a member of group %q", username, groupName)
 	}
 
 	validRoles := map[string]bool{
@@ -83,7 +83,7 @@ func AddMember(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Invalid Role", Body: []string{"Role must be one of: owner, aclkeeper, gatekeeper, member, guest"}}},
 		})
-		return nil
+		return fmt.Errorf("invalid group role: %s", role)
 	}
 
 	newUG := models.UserGroup{UserID: u.ID, GroupID: g.ID, Role: role}

--- a/internal/commands/group/add_member_test.go
+++ b/internal/commands/group/add_member_test.go
@@ -44,11 +44,35 @@ func TestAddMember_InvalidRole(t *testing.T) {
 		t.Fatalf("create group: %v", err)
 	}
 
-	// The function accepts any non-empty role string; "invalidrole" creates the row
-	// but we verify it does not panic.
-	_ = AddMember(db, admin, []string{
+	err := AddMember(db, admin, []string{
 		"--group", "mygroup",
 		"--user", "alice",
 		"--role", "invalidrole",
 	})
+	if err == nil {
+		t.Fatal("expected invalid role error")
+	}
+}
+
+func TestAddMember_DuplicateReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	admin := newAdminUser(t, db, "admin")
+	alice := newRegularUser(t, db, "alice")
+
+	g := models.Group{Name: "mygroup"}
+	if err := db.Create(&g).Error; err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	if err := db.Create(&models.UserGroup{UserID: alice.ID, GroupID: g.ID, Role: models.GroupRoleMember}).Error; err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+
+	err := AddMember(db, admin, []string{
+		"--group", "mygroup",
+		"--user", "alice",
+		"--role", "member",
+	})
+	if err == nil {
+		t.Fatal("expected duplicate member error")
+	}
 }

--- a/internal/commands/group/info.go
+++ b/internal/commands/group/info.go
@@ -30,11 +30,11 @@ func Info(db *gorm.DB, currentUser *models.User, args []string) error {
 		return err
 	}
 
-	if !currentUser.CanDo(db, "groupInfo", "") {
+	if !currentUser.CanDo(db, "groupInfo", groupName) {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Group Info",
 			BlockType: "error",
-			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: []string{"You do not have permission to view group information."}}},
+			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: models.DescribeVisibilityDenial(models.VisibilityDeniedGroupPolicy, groupName, "")}},
 		})
 		return fmt.Errorf("access denied for user %s", currentUser.Username)
 	}

--- a/internal/commands/group/list.go
+++ b/internal/commands/group/list.go
@@ -37,6 +37,14 @@ func List(db *gorm.DB, user *models.User, args []string) error {
 		})
 		return fmt.Errorf("access denied for %s", user.Username)
 	}
+	if *all && !user.CanListAllGroups(db) {
+		console.DisplayBlock(console.ContentBlock{
+			Title:     "Group List",
+			BlockType: "error",
+			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: models.DescribeVisibilityDenial(models.VisibilityDeniedGlobalGroupList, "", "")}},
+		})
+		return fmt.Errorf("access denied for %s", user.Username)
+	}
 
 	var buf bytes.Buffer
 	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)

--- a/internal/commands/group/list_accesses.go
+++ b/internal/commands/group/list_accesses.go
@@ -34,7 +34,7 @@ func ListAccesses(db *gorm.DB, currentUser *models.User, args []string) error {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "List Group Access",
 			BlockType: "error",
-			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: []string{"You do not have permission to list accesses for this group."}}},
+			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: models.DescribeVisibilityDenial(models.VisibilityDeniedGroupPolicy, groupName, "")}},
 		})
 		return fmt.Errorf("access denied for %s", currentUser.Username)
 	}

--- a/internal/commands/group/list_aliases.go
+++ b/internal/commands/group/list_aliases.go
@@ -34,7 +34,7 @@ func ListAliases(db *gorm.DB, currentUser *models.User, args []string) error {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "List Group Aliases",
 			BlockType: "error",
-			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: []string{"You do not have permission to list aliases for this group."}}},
+			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: models.DescribeVisibilityDenial(models.VisibilityDeniedGroupPolicy, groupName, "")}},
 		})
 		return fmt.Errorf("access denied for %s", currentUser.Username)
 	}

--- a/internal/commands/group/list_db_accesses.go
+++ b/internal/commands/group/list_db_accesses.go
@@ -34,7 +34,7 @@ func ListDBAccesses(db *gorm.DB, currentUser *models.User, args []string) error 
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "List Group DB Access",
 			BlockType: "error",
-			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: []string{"You do not have permission to list DB accesses for this group."}}},
+			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: models.DescribeVisibilityDenial(models.VisibilityDeniedGroupPolicy, groupName, "")}},
 		})
 		return fmt.Errorf("access denied for %s", currentUser.Username)
 	}

--- a/internal/commands/group/list_db_aliases.go
+++ b/internal/commands/group/list_db_aliases.go
@@ -34,7 +34,7 @@ func ListDBAliases(db *gorm.DB, currentUser *models.User, args []string) error {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "List Group DB Aliases",
 			BlockType: "error",
-			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: []string{"You do not have permission to list aliases for this group."}}},
+			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: models.DescribeVisibilityDenial(models.VisibilityDeniedGroupPolicy, groupName, "")}},
 		})
 		return fmt.Errorf("access denied for %s", currentUser.Username)
 	}

--- a/internal/commands/group/list_egress_keys.go
+++ b/internal/commands/group/list_egress_keys.go
@@ -33,7 +33,7 @@ func ListEgressKeys(db *gorm.DB, currentUser *models.User, args []string) error 
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "List Egress Keys",
 			BlockType: "error",
-			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: []string{"You do not have permission to list egress keys for this group."}}},
+			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: models.DescribeVisibilityDenial(models.VisibilityDeniedEgressPolicy, groupName, "")}},
 		})
 		return fmt.Errorf("access denied for %s", currentUser.Username)
 	}

--- a/internal/commands/group/list_guest_accesses.go
+++ b/internal/commands/group/list_guest_accesses.go
@@ -35,9 +35,17 @@ func ListGuestAccesses(db *gorm.DB, currentUser *models.User, args []string) err
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "List Guest Accesses",
 			BlockType: "error",
-			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: []string{"You do not have permission to list guest accesses for this group."}}},
+			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: models.DescribeVisibilityDenial(models.VisibilityDeniedGroupPolicy, groupName, "")}},
 		})
 		return fmt.Errorf("access denied for %s", currentUser.Username)
+	}
+	if !currentUser.CanInspectGuestGrantTarget(db, groupName, account) {
+		console.DisplayBlock(console.ContentBlock{
+			Title:     "List Guest Accesses",
+			BlockType: "error",
+			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: models.DescribeVisibilityDenial(models.VisibilityDeniedGuestOwnOnly, groupName, account)}},
+		})
+		return fmt.Errorf("access denied for %s on guest grants of %s in group %s", currentUser.Username, account, groupName)
 	}
 
 	var group models.Group
@@ -58,18 +66,6 @@ func ListGuestAccesses(db *gorm.DB, currentUser *models.User, args []string) err
 			Sections:  []console.SectionContent{{SubTitle: "Not Found", Body: []string{fmt.Sprintf("User '%s' not found.", account)}}},
 		})
 		return err
-	}
-
-	var currentMembership models.UserGroup
-	if err := db.Where("user_id = ? AND group_id = ? AND deleted_at IS NULL", currentUser.ID, group.ID).First(&currentMembership).Error; err == nil {
-		if currentMembership.IsGuest() && !strings.EqualFold(account, currentUser.Username) {
-			console.DisplayBlock(console.ContentBlock{
-				Title:     "List Guest Accesses",
-				BlockType: "error",
-				Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: []string{"Guest users can only list their own guest accesses."}}},
-			})
-			return fmt.Errorf("guest user %s attempted to list accesses for %s", currentUser.Username, account)
-		}
 	}
 
 	var grants []models.GroupGuestAccess

--- a/internal/commands/group/list_guest_db_accesses.go
+++ b/internal/commands/group/list_guest_db_accesses.go
@@ -35,9 +35,17 @@ func ListGuestDBAccesses(db *gorm.DB, currentUser *models.User, args []string) e
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "List Guest DB Accesses",
 			BlockType: "error",
-			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: []string{"You do not have permission to list guest DB accesses for this group."}}},
+			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: models.DescribeVisibilityDenial(models.VisibilityDeniedGroupPolicy, groupName, "")}},
 		})
 		return fmt.Errorf("access denied for %s", currentUser.Username)
+	}
+	if !currentUser.CanInspectGuestGrantTarget(db, groupName, account) {
+		console.DisplayBlock(console.ContentBlock{
+			Title:     "List Guest DB Accesses",
+			BlockType: "error",
+			Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: models.DescribeVisibilityDenial(models.VisibilityDeniedGuestOwnOnly, groupName, account)}},
+		})
+		return fmt.Errorf("access denied for %s on guest db grants of %s in group %s", currentUser.Username, account, groupName)
 	}
 
 	var group models.Group
@@ -58,18 +66,6 @@ func ListGuestDBAccesses(db *gorm.DB, currentUser *models.User, args []string) e
 			Sections:  []console.SectionContent{{SubTitle: "Not Found", Body: []string{fmt.Sprintf("User '%s' not found.", account)}}},
 		})
 		return err
-	}
-
-	var currentMembership models.UserGroup
-	if err := db.Where("user_id = ? AND group_id = ? AND deleted_at IS NULL", currentUser.ID, group.ID).First(&currentMembership).Error; err == nil {
-		if currentMembership.IsGuest() && !strings.EqualFold(account, currentUser.Username) {
-			console.DisplayBlock(console.ContentBlock{
-				Title:     "List Guest DB Accesses",
-				BlockType: "error",
-				Sections:  []console.SectionContent{{SubTitle: "Access Denied", Body: []string{"Guest users can only list their own guest database accesses."}}},
-			})
-			return fmt.Errorf("guest user %s attempted to list db accesses for %s", currentUser.Username, account)
-		}
 	}
 
 	var grants []models.GroupGuestDBAccess

--- a/internal/commands/group/testhelper_test.go
+++ b/internal/commands/group/testhelper_test.go
@@ -1,6 +1,9 @@
 package group
 
 import (
+	"bytes"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/glebarez/sqlite"
@@ -44,4 +47,25 @@ func newRegularUser(t *testing.T, db *gorm.DB, username string) *models.User {
 		t.Fatalf("create regular user: %v", err)
 	}
 	return &u
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	fn()
+
+	_ = w.Close()
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("copy stdout: %v", err)
+	}
+	_ = r.Close()
+	return buf.String()
 }

--- a/internal/commands/group/visibility_messages_test.go
+++ b/internal/commands/group/visibility_messages_test.go
@@ -1,0 +1,103 @@
+package group
+
+import (
+	"strings"
+	"testing"
+
+	"goBastion/internal/models"
+)
+
+func TestGroupListAllDeniedMessageIncludesCurrentPolicy(t *testing.T) {
+	db := newTestDB(t)
+	user := newRegularUser(t, db, "alice")
+	models.SetGroupVisibilityMode("members")
+	defer models.SetGroupVisibilityMode("open")
+
+	out := captureStdout(t, func() {
+		_ = List(db, user, []string{"--all"})
+	})
+
+	for _, want := range []string{
+		"You do not have permission to list all groups under the current visibility policy.",
+		"Current policy: security.group_visibility.mode=members",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestGroupInfoDeniedMessageIncludesRequiredRoleHint(t *testing.T) {
+	db := newTestDB(t)
+	user := newRegularUser(t, db, "alice")
+	group := models.Group{Name: "infra"}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	models.SetGroupVisibilityMode("managers")
+	defer models.SetGroupVisibilityMode("open")
+
+	out := captureStdout(t, func() {
+		_ = Info(db, user, []string{"--group", "infra"})
+	})
+
+	for _, want := range []string{
+		"You do not have permission to view group 'infra' under the current visibility policy.",
+		"Current policy: security.group_visibility.mode=managers",
+		"Required: owner, aclkeeper, gatekeeper, admin, or superowner in the target group.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestGroupListEgressKeysDeniedMessageIncludesPrivatePolicyHint(t *testing.T) {
+	db := newTestDB(t)
+	user := newRegularUser(t, db, "alice")
+	group := models.Group{Name: "infra"}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	models.SetEgressKeyVisibilityMode("private")
+	defer models.SetEgressKeyVisibilityMode("discoverable")
+
+	out := captureStdout(t, func() {
+		_ = ListEgressKeys(db, user, []string{"--group", "infra"})
+	})
+
+	for _, want := range []string{
+		"You do not have permission to list egress keys for group 'infra'.",
+		"Current policy: security.egress_key_visibility.mode=private",
+		"Required: group owner, admin, or superowner.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestGuestOwnOnlyDeniedMessageIncludesRequestedAccount(t *testing.T) {
+	db := newTestDB(t)
+	group := models.Group{Name: "infra"}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+	guest := newRegularUser(t, db, "bob")
+	if err := db.Create(&models.UserGroup{UserID: guest.ID, GroupID: group.ID, Role: models.GroupRoleGuest}).Error; err != nil {
+		t.Fatalf("create guest membership: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		_ = ListGuestAccesses(db, guest, []string{"--group", "infra", "--account", "alice"})
+	})
+
+	for _, want := range []string{
+		"Guest users can only view their own grants in this group.",
+		"Requested account: alice",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, out)
+		}
+	}
+}

--- a/internal/commands/realm/create.go
+++ b/internal/commands/realm/create.go
@@ -11,6 +11,7 @@ import (
 	"goBastion/internal/utils/console"
 	"goBastion/internal/utils/validation"
 
+	"golang.org/x/crypto/ssh"
 	"gorm.io/gorm"
 )
 
@@ -39,7 +40,10 @@ func Create(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Usage", Body: []string{"Usage: realmCreate --realm <name> --bastion <host> [--port <22>] --from <cidrs> --public-key <ssh-pubkey>"}}},
 		})
-		return nil
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("missing required arguments")
 	}
 
 	realmName = strings.ToLower(strings.TrimSpace(realmName))
@@ -76,13 +80,14 @@ func Create(db *gorm.DB, currentUser *models.User, args []string) error {
 		})
 		return nil
 	}
-	if !strings.HasPrefix(strings.TrimSpace(publicKey), "ssh-") {
+	publicKey = strings.TrimSpace(publicKey)
+	if _, _, _, _, err := ssh.ParseAuthorizedKey([]byte(publicKey)); err != nil {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Realm Create",
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Invalid Key", Body: []string{"--public-key must be an SSH public key"}}},
 		})
-		return nil
+		return fmt.Errorf("invalid realm public key: %w", err)
 	}
 
 	var existing models.Realm
@@ -100,7 +105,7 @@ func Create(db *gorm.DB, currentUser *models.User, args []string) error {
 		BastionHost: bastionHost,
 		BastionPort: bastionPort,
 		AllowedFrom: strings.TrimSpace(allowedFrom),
-		PublicKey:   strings.TrimSpace(publicKey),
+		PublicKey:   publicKey,
 		Enabled:     true,
 		CreatedByID: currentUser.ID,
 	}

--- a/internal/commands/realm/create_test.go
+++ b/internal/commands/realm/create_test.go
@@ -6,6 +6,8 @@ import (
 	"goBastion/internal/models"
 )
 
+const testRealmPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGT0i7K7nM5j9l9M5HqY9v9M0N4k8m2JQ4VnV8z0V6hK test@example"
+
 func TestRealmCreate_Success(t *testing.T) {
 	db := newTestDB(t)
 	admin := newAdminUser(t, db, "admin")
@@ -15,7 +17,7 @@ func TestRealmCreate_Success(t *testing.T) {
 		"--bastion", "bastion.example.com",
 		"--port", "22",
 		"--from", "10.0.0.0/8",
-		"--public-key", "ssh-ed25519 AAAA...",
+		"--public-key", testRealmPublicKey,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -44,15 +46,30 @@ func TestRealmCreate_MissingArgs(t *testing.T) {
 	db := newTestDB(t)
 	admin := newAdminUser(t, db, "admin")
 
-	// Missing --bastion, --from, --public-key triggers usage error.
 	err := Create(db, admin, []string{"--realm", "myrealm"})
-	if err != nil {
-		t.Fatalf("expected nil (usage error prints and returns nil), got: %v", err)
+	if err == nil {
+		t.Fatal("expected usage error")
 	}
 
 	var count int64
 	db.Model(&models.Realm{}).Count(&count)
 	if count != 0 {
 		t.Fatalf("expected no realm created, got %d", count)
+	}
+}
+
+func TestRealmCreate_InvalidPublicKey(t *testing.T) {
+	db := newTestDB(t)
+	admin := newAdminUser(t, db, "admin")
+
+	err := Create(db, admin, []string{
+		"--realm", "remote-bastion",
+		"--bastion", "bastion.example.com",
+		"--port", "22",
+		"--from", "10.0.0.0/8",
+		"--public-key", "ssh-ed25519 not-a-real-key",
+	})
+	if err == nil {
+		t.Fatal("expected invalid public key error")
 	}
 }

--- a/internal/commands/realm/delete.go
+++ b/internal/commands/realm/delete.go
@@ -25,7 +25,10 @@ func Delete(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Usage", Body: []string{"Usage: realmDelete --realm <name>"}}},
 		})
-		return nil
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("missing required arguments")
 	}
 
 	if !currentUser.CanDo(db, "realmDelete", "") {
@@ -47,7 +50,7 @@ func Delete(db *gorm.DB, currentUser *models.User, args []string) error {
 		if res.Error != nil {
 			return res.Error
 		}
-		return nil
+		return fmt.Errorf("realm %q not found", strings.ToLower(strings.TrimSpace(realmName)))
 	}
 
 	console.DisplayBlock(console.ContentBlock{

--- a/internal/commands/realm/delete_test.go
+++ b/internal/commands/realm/delete_test.go
@@ -39,10 +39,9 @@ func TestRealmDelete_NotFound(t *testing.T) {
 	db := newTestDB(t)
 	admin := newAdminUser(t, db, "admin")
 
-	// Deleting a non-existent realm returns nil (no error).
 	err := Delete(db, admin, []string{"--realm", "nonexistent"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err == nil {
+		t.Fatal("expected not found error")
 	}
 }
 

--- a/internal/commands/registry/handlers.go
+++ b/internal/commands/registry/handlers.go
@@ -147,6 +147,7 @@ func buildHandlers(db *gorm.DB, user *models.User, log *slog.Logger, adapter osa
 		"exit": nil,
 
 		// Bastion Config
-		"bastionConfig": func() error { return cmdconfig.BastionConfig(db, user) },
+		"bastionConfig":          func() error { return cmdconfig.BastionConfig(db, user) },
+		"bastionShowSFTPHostKey": func() error { return cmdconfig.ShowSFTPProxyHostKey(db, user) },
 	}
 }

--- a/internal/commands/registry/specs.go
+++ b/internal/commands/registry/specs.go
@@ -428,4 +428,6 @@ var commandRegistry = []CommandMeta{
 	// --- Bastion Config ---
 	{Name: "bastionConfig", Description: "Interactive bastion configuration manager", Permission: "bastionConfig",
 		Category: "BASTION CONFIG", SubCategory: "Configuration"},
+	{Name: "bastionShowSFTPHostKey", Description: "Show the stable SFTP proxy host key for client distribution", Permission: "bastionConfig",
+		Category: "BASTION CONFIG", SubCategory: "Configuration"},
 }

--- a/internal/commands/restricted/grants.go
+++ b/internal/commands/restricted/grants.go
@@ -31,7 +31,10 @@ func GrantAdd(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Usage", Body: []string{"Usage: restrictedGrantAdd --user <username> --command <command>"}}},
 		})
-		return nil
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("missing required arguments")
 	}
 
 	var user models.User
@@ -55,7 +58,7 @@ func GrantAdd(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Error", Body: []string{"Failed to add grant (it may already exist)."}}},
 		})
-		return nil
+		return err
 	}
 
 	console.DisplayBlock(console.ContentBlock{
@@ -80,7 +83,10 @@ func GrantDel(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Usage", Body: []string{"Usage: restrictedGrantDel --user <username> --command <command>"}}},
 		})
-		return nil
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("missing required arguments")
 	}
 
 	var user models.User
@@ -103,7 +109,7 @@ func GrantDel(db *gorm.DB, currentUser *models.User, args []string) error {
 		if res.Error != nil {
 			return res.Error
 		}
-		return nil
+		return fmt.Errorf("restricted grant not found")
 	}
 
 	console.DisplayBlock(console.ContentBlock{
@@ -127,7 +133,7 @@ func GrantList(db *gorm.DB, currentUser *models.User, args []string) error {
 			BlockType: "error",
 			Sections:  []console.SectionContent{{SubTitle: "Usage", Body: []string{"Usage: restrictedGrantList [--user <username>]"}}},
 		})
-		return nil
+		return err
 	}
 
 	query := db.Preload("User").Preload("GrantedBy").Order("created_at desc")

--- a/internal/commands/restricted/grants_test.go
+++ b/internal/commands/restricted/grants_test.go
@@ -1,6 +1,7 @@
 package restricted
 
 import (
+	"errors"
 	"testing"
 
 	"goBastion/internal/models"
@@ -70,13 +71,55 @@ func TestGrantDel_NotFound(t *testing.T) {
 	admin := newAdminUser(t, db, "admin")
 	_ = newRegularUser(t, db, "alice")
 
-	// Deleting a non-existent grant returns nil.
 	err := GrantDel(db, admin, []string{
 		"--user", "alice",
 		"--command", "nonexistent",
 	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err == nil {
+		t.Fatal("expected not found error")
+	}
+}
+
+func TestGrantAdd_DuplicateReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	admin := newAdminUser(t, db, "admin")
+	alice := newRegularUser(t, db, "alice")
+
+	g := models.RestrictedCommandGrant{
+		UserID:      alice.ID,
+		Command:     "realmCreate",
+		GrantedByID: admin.ID,
+	}
+	if err := db.Create(&g).Error; err != nil {
+		t.Fatalf("seed grant: %v", err)
+	}
+
+	err := GrantAdd(db, admin, []string{
+		"--user", "alice",
+		"--command", "realmCreate",
+	})
+	if err == nil {
+		t.Fatal("expected duplicate grant error")
+	}
+}
+
+func TestGrantList_InvalidArgsReturnError(t *testing.T) {
+	db := newTestDB(t)
+	admin := newAdminUser(t, db, "admin")
+
+	err := GrantList(db, admin, []string{"--invalid"})
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestGrantAdd_MissingArgsReturnError(t *testing.T) {
+	db := newTestDB(t)
+	admin := newAdminUser(t, db, "admin")
+
+	err := GrantAdd(db, admin, []string{"--user", "alice"})
+	if err == nil || !errors.Is(err, err) {
+		t.Fatal("expected missing args error")
 	}
 }
 

--- a/internal/commands/self/add_access.go
+++ b/internal/commands/self/add_access.go
@@ -148,7 +148,7 @@ func AddAccess(db *gorm.DB, user *models.User, args []string) error {
 				{SubTitle: "Error", Body: []string{"Access already exists for this server with the given username and port."}},
 			},
 		})
-		return nil
+		return fmt.Errorf("personal access already exists for %s@%s:%d", username, server, port)
 	} else if !errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Add Personal Access",

--- a/internal/commands/self/add_access_test.go
+++ b/internal/commands/self/add_access_test.go
@@ -32,14 +32,41 @@ func TestAddAccess_MissingServer(t *testing.T) {
 	user := newRegularUser(t, db, "alice")
 
 	// Missing --server; should not panic, no DB entry
-	_ = AddAccess(db, user, []string{
+	err := AddAccess(db, user, []string{
 		"--username", "root",
 		"--port", "22",
 	})
+	if err == nil {
+		t.Fatal("expected missing required arguments error")
+	}
 
 	var count int64
 	db.Model(&models.SelfAccess{}).Where("user_id = ?", user.ID).Count(&count)
 	if count != 0 {
 		t.Fatalf("expected 0 access entries, got %d", count)
+	}
+}
+
+func TestAddAccess_DuplicateReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	user := newRegularUser(t, db, "alice")
+
+	if err := AddAccess(db, user, []string{
+		"--server", "1.2.3.4",
+		"--username", "root",
+		"--port", "22",
+		"--force",
+	}); err != nil {
+		t.Fatalf("seed access: %v", err)
+	}
+
+	err := AddAccess(db, user, []string{
+		"--server", "1.2.3.4",
+		"--username", "root",
+		"--port", "22",
+		"--force",
+	})
+	if err == nil {
+		t.Fatal("expected duplicate access error")
 	}
 }

--- a/internal/commands/self/add_alias.go
+++ b/internal/commands/self/add_alias.go
@@ -2,6 +2,7 @@ package self
 
 import (
 	"flag"
+	"fmt"
 	"strings"
 
 	"goBastion/internal/models"
@@ -35,7 +36,7 @@ func AddAlias(db *gorm.DB, user *models.User, args []string) error {
 				{SubTitle: "Usage", Body: []string{"selfAddAlias --alias <alias> --hostname <host_name>"}},
 			},
 		})
-		return nil
+		return fmt.Errorf("missing required arguments")
 	}
 	if !validation.IsValidHost(hostname) {
 		console.DisplayBlock(console.ContentBlock{
@@ -45,7 +46,7 @@ func AddAlias(db *gorm.DB, user *models.User, args []string) error {
 				{SubTitle: "Invalid Hostname", Body: []string{"Hostname contains invalid characters."}},
 			},
 		})
-		return nil
+		return fmt.Errorf("invalid hostname: %s", hostname)
 	}
 	var existing models.Aliases
 	if err := db.Where("LOWER(resolve_from) = ? AND user_id = ? AND deleted_at IS NULL", strings.ToLower(alias), user.ID).First(&existing).Error; err == nil {
@@ -56,7 +57,7 @@ func AddAlias(db *gorm.DB, user *models.User, args []string) error {
 				{SubTitle: "Duplicate", Body: []string{"An alias with this name already exists."}},
 			},
 		})
-		return nil
+		return fmt.Errorf("personal alias %q already exists", alias)
 	}
 	newHost := models.Aliases{
 		ResolveFrom: alias,

--- a/internal/commands/self/add_alias_test.go
+++ b/internal/commands/self/add_alias_test.go
@@ -15,8 +15,8 @@ func TestAddAliasRejectsCaseInsensitiveDuplicateInSelfScope(t *testing.T) {
 		t.Fatalf("seed alias: %v", err)
 	}
 
-	if err := AddAlias(db, user, []string{"--alias", "prod", "--hostname", "srv2"}); err != nil {
-		t.Fatalf("AddAlias returned error: %v", err)
+	if err := AddAlias(db, user, []string{"--alias", "prod", "--hostname", "srv2"}); err == nil {
+		t.Fatal("expected duplicate alias error")
 	}
 
 	var count int64

--- a/internal/commands/self/add_db_access.go
+++ b/internal/commands/self/add_db_access.go
@@ -125,7 +125,7 @@ func AddDBAccess(db *gorm.DB, user *models.User, args []string) error {
 				{SubTitle: "Error", Body: []string{"Access already exists for this host, port, and protocol."}},
 			},
 		})
-		return nil
+		return fmt.Errorf("personal DB access already exists for %s:%d/%s", host, port, protocol)
 	} else if !errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Add Personal DB Access",

--- a/internal/commands/self/add_db_alias.go
+++ b/internal/commands/self/add_db_alias.go
@@ -2,6 +2,7 @@ package self
 
 import (
 	"flag"
+	"fmt"
 	"strings"
 
 	"goBastion/internal/models"
@@ -38,7 +39,7 @@ func AddDBAlias(db *gorm.DB, user *models.User, args []string) error {
 				{SubTitle: "Usage", Body: []string{"selfAddDBAlias --alias <alias> --host <host> --port <port> --protocol <protocol>"}},
 			},
 		})
-		return nil
+		return fmt.Errorf("missing required arguments")
 	}
 	if !validation.IsValidDBProtocol(protocol) {
 		console.DisplayBlock(console.ContentBlock{
@@ -48,7 +49,7 @@ func AddDBAlias(db *gorm.DB, user *models.User, args []string) error {
 				{SubTitle: "Invalid Protocol", Body: []string{"Protocol contains invalid characters."}},
 			},
 		})
-		return nil
+		return fmt.Errorf("invalid protocol: %s", protocol)
 	}
 	var existing models.DatabaseAlias
 	if err := db.Where("LOWER(resolve_from) = ? AND user_id = ? AND deleted_at IS NULL", strings.ToLower(alias), user.ID).First(&existing).Error; err == nil {
@@ -59,7 +60,7 @@ func AddDBAlias(db *gorm.DB, user *models.User, args []string) error {
 				{SubTitle: "Duplicate", Body: []string{"An alias with this name already exists."}},
 			},
 		})
-		return nil
+		return fmt.Errorf("personal DB alias %q already exists", alias)
 	}
 	newAlias := models.DatabaseAlias{
 		ResolveFrom: alias,

--- a/internal/commands/self/add_db_alias_test.go
+++ b/internal/commands/self/add_db_alias_test.go
@@ -15,8 +15,8 @@ func TestAddDBAliasRejectsCaseInsensitiveDuplicateInSelfScope(t *testing.T) {
 		t.Fatalf("seed db alias: %v", err)
 	}
 
-	if err := AddDBAlias(db, user, []string{"--alias", "proddb", "--host", "db2", "--port", "5432", "--protocol", "postgres"}); err != nil {
-		t.Fatalf("AddDBAlias returned error: %v", err)
+	if err := AddDBAlias(db, user, []string{"--alias", "proddb", "--host", "db2", "--port", "5432", "--protocol", "postgres"}); err == nil {
+		t.Fatal("expected duplicate db alias error")
 	}
 
 	var count int64

--- a/internal/commands/self/del_alias.go
+++ b/internal/commands/self/del_alias.go
@@ -37,7 +37,7 @@ func DelAlias(db *gorm.DB, user *models.User, args []string) error {
 				{SubTitle: "Usage", Body: []string{"selfDelAlias --id <alias_id>"}},
 			},
 		})
-		return nil
+		return fmt.Errorf("missing required arguments")
 	}
 	parsedID, err := uuid.Parse(hostID)
 	if err != nil {
@@ -60,7 +60,7 @@ func DelAlias(db *gorm.DB, user *models.User, args []string) error {
 				{SubTitle: "Error", Body: []string{"No alias found for the current user with the given ID."}},
 			},
 		})
-		return nil
+		return fmt.Errorf("personal alias not found for id %s", hostID)
 	} else if result.Error != nil {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Delete Personal Alias",

--- a/internal/commands/self/del_db_alias.go
+++ b/internal/commands/self/del_db_alias.go
@@ -37,7 +37,7 @@ func DelDBAlias(db *gorm.DB, user *models.User, args []string) error {
 				{SubTitle: "Usage", Body: []string{"selfDelDBAlias --id <alias_id>"}},
 			},
 		})
-		return nil
+		return fmt.Errorf("missing required arguments")
 	}
 	parsedID, err := uuid.Parse(aliasID)
 	if err != nil {
@@ -60,7 +60,7 @@ func DelDBAlias(db *gorm.DB, user *models.User, args []string) error {
 				{SubTitle: "Error", Body: []string{"No alias found for the current user with the given ID."}},
 			},
 		})
-		return nil
+		return fmt.Errorf("personal DB alias not found for id %s", aliasID)
 	} else if result.Error != nil {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "Delete Personal DB Alias",

--- a/internal/commands/ssh/connect.go
+++ b/internal/commands/ssh/connect.go
@@ -169,7 +169,7 @@ func Connect(db *gorm.DB, user models.User, logger slog.Logger, params string) e
 					log.Warn("mfa_failure", slog.String("event", "mfa_totp"), slog.String("reason", "no totp secret"), slog.String("to", access.Source))
 					return fmt.Errorf("⛔ MFA required but no TOTP secret configured")
 				}
-				if !promptTOTP(user, log) {
+				if !promptTOTP(db, &user, log) {
 					return fmt.Errorf("⛔ MFA validation failed")
 				}
 			}
@@ -256,7 +256,7 @@ func inferSSHUsername(db *gorm.DB, user models.User, host string, port int64) (s
 func resolveAccessUsername(username string) (string, bool) {
 	switch {
 	case username == "*":
-		return "root", true
+		return config.Get().Security.DefaultWildcardUsername, true
 	case username != "":
 		return username, true
 	default:
@@ -581,11 +581,11 @@ func detectProtocol(remoteCmd string) string {
 	}
 }
 
-// promptTOTP reads a TOTP code from stdin and verifies it.
+// promptTOTP reads a TOTP code or backup code from stdin and verifies it.
 // Used for JIT MFA enforcement at connection time.
-func promptTOTP(user models.User, log *slog.Logger) bool {
+func promptTOTP(db *gorm.DB, user *models.User, log *slog.Logger) bool {
 	for attempt := 1; attempt <= config.Get().MFA.MaxAttempts; attempt++ {
-		fmt.Printf("🔐 This group requires MFA. Enter TOTP code [attempt %d/%d]: ", attempt, config.Get().MFA.MaxAttempts)
+		fmt.Printf("🔐 This group requires MFA. Enter TOTP code (or backup code) [attempt %d/%d]: ", attempt, config.Get().MFA.MaxAttempts)
 		reader := bufio.NewReader(os.Stdin)
 		code, err := reader.ReadString('\n')
 		if err != nil {
@@ -593,17 +593,33 @@ func promptTOTP(user models.User, log *slog.Logger) bool {
 			fmt.Fprintln(os.Stderr, "⛔ Could not read TOTP code.")
 			return false
 		}
-		if totpUtil.Verify(user.TOTPSecret, strings.TrimSpace(code)) {
+		code = strings.TrimSpace(code)
+		if totpUtil.Verify(user.TOTPSecret, code) {
 			log.Info("mfa_success", slog.String("event", "mfa_totp"), slog.String("user", user.Username))
 			return true
 		}
+		if user.BackupCodes != "" {
+			matched, updatedJSON, err := totpUtil.VerifyAndConsumeBackupCode(code, user.BackupCodes)
+			if err != nil {
+				log.Warn("mfa_error", slog.String("event", "mfa_backup_code"), slog.String("user", user.Username), slog.String("error", err.Error()))
+			} else if matched {
+				if dbErr := db.Model(user).Update("backup_codes", updatedJSON).Error; dbErr != nil {
+					log.Error("mfa_backup_code_db_error", slog.String("user", user.Username), slog.String("error", dbErr.Error()))
+					fmt.Println("⛔ Internal error saving backup code. Contact your admin.")
+					return false
+				}
+				user.BackupCodes = updatedJSON
+				log.Info("mfa_success", slog.String("event", "mfa_backup_code"), slog.String("user", user.Username))
+				return true
+			}
+		}
 		if attempt < config.Get().MFA.MaxAttempts {
-			fmt.Println("⛔ Invalid TOTP code. Try again.")
+			fmt.Println("⛔ Invalid TOTP or backup code. Try again.")
 			time.Sleep(time.Duration(attempt) * time.Duration(config.Get().MFA.BackoffBase)) // linear backoff
 		}
 	}
 	log.Warn("mfa_failure", slog.String("event", "mfa_totp"), slog.String("user", user.Username))
-	fmt.Println("⛔ Invalid TOTP code. Access denied.")
+	fmt.Println("⛔ Invalid TOTP or backup code. Access denied.")
 	return false
 }
 
@@ -924,15 +940,11 @@ func TCPProxy(db *gorm.DB, user models.User, logger slog.Logger, host, port stri
 		return err
 	}
 
-	// JIT MFA enforcement for passthrough flows when the selected group policy requires it.
-	if access.MFARequired && !user.TOTPEnabled {
-		if user.TOTPSecret == "" {
-			log.Warn("mfa_failure", slog.String("event", "mfa_totp"), slog.String("reason", "no totp secret"), slog.String("to", access.Source))
-			return fmt.Errorf("⛔ This access requires MFA but no TOTP secret is configured. Run selfSetupTOTP first")
-		}
-		if !promptTOTP(user, log) {
-			return fmt.Errorf("⛔ Access denied: MFA validation failed")
-		}
+	// Raw TCP proxy is an opaque byte stream; it cannot safely carry an MFA
+	// prompt without corrupting the protocol spoken by the client.
+	if access.MFARequired {
+		log.Warn("mfa_unavailable", slog.String("event", "mfa_totp"), slog.String("reason", "tcp_proxy_jit_mfa"), slog.String("to", access.Source))
+		return fmt.Errorf("⛔ TCP proxy (-W) is unavailable when this access requires JIT MFA. Use an interactive SSH/SFTP flow instead")
 	}
 
 	log.Info("tcp_proxy")
@@ -949,14 +961,9 @@ func TCPProxy(db *gorm.DB, user models.User, logger slog.Logger, host, port stri
 // proxying the sftp subsystem — no client key on the target needed.
 //
 // Invoked when SSH_ORIGINAL_COMMAND = "sftp-session user@host:port".
-// Client config example:
-//
-// Host myserver
-//
-//	User root
-//	ProxyCommand ssh -p 2222 -- user@bastion "sftp-session root@%h:%p"
-//	StrictHostKeyChecking no
-//	UserKnownHostsFile /dev/null
+// The client must pin the stable SFTP proxy host key in known_hosts for the
+// SSH host alias used on the client side (e.g. "my-server"), not for the
+// bastion hostname used inside ProxyCommand.
 func SFTPSession(db *gorm.DB, user models.User, logger slog.Logger, params string) error {
 	sshUser, sshHost, sshPort, _, err := parseSSHCommand(params)
 	if err != nil {
@@ -1004,7 +1011,7 @@ func SFTPSession(db *gorm.DB, user models.User, logger slog.Logger, params strin
 			log.Warn("mfa_failure", slog.String("event", "mfa_totp"), slog.String("reason", "no totp secret"), slog.String("to", access.Source))
 			return fmt.Errorf("⛔ This access requires MFA but no TOTP secret is configured. Run selfSetupTOTP first")
 		}
-		if !promptTOTP(user, log) {
+		if !promptTOTP(db, &user, log) {
 			return fmt.Errorf("⛔ Access denied: MFA validation failed")
 		}
 	}
@@ -1015,7 +1022,7 @@ func SFTPSession(db *gorm.DB, user models.User, logger slog.Logger, params strin
 	}
 
 	log.Info("sftp_session", slog.String("to", access.Source))
-	if err = sftpProxy.Proxy(access); err != nil {
+	if err = sftpProxy.Proxy(db, access); err != nil {
 		log.Error("sftp_session", slog.String("error", err.Error()))
 		return err
 	}

--- a/internal/commands/ssh/connect_test.go
+++ b/internal/commands/ssh/connect_test.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"log"
+	"log/slog"
 	"os"
 	"strings"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
+	"goBastion/internal/config"
 	"goBastion/internal/models"
 )
 
@@ -323,6 +325,11 @@ func TestInferSSHUsername_ExactBeforeWildcard(t *testing.T) {
 // --- normalizeWildcardUsername tests ---
 
 func TestNormalizeWildcardUsername(t *testing.T) {
+	config.ResetForTesting()
+	t.Cleanup(config.ResetForTesting)
+	cfg := config.Load()
+	cfg.Security.DefaultWildcardUsername = "operator"
+
 	tests := []struct {
 		name      string
 		stored    string
@@ -330,7 +337,7 @@ func TestNormalizeWildcardUsername(t *testing.T) {
 		want      string
 	}{
 		{"wildcard with requested username", "*", "deploy", "deploy"},
-		{"wildcard without requested username defaults to root", "*", "", "root"},
+		{"wildcard without requested username uses configured default", "*", "", "operator"},
 		{"exact stored is never overridden", "admin", "deploy", "admin"},
 		{"exact stored with empty requested", "operator", "", "operator"},
 	}
@@ -342,6 +349,42 @@ func TestNormalizeWildcardUsername(t *testing.T) {
 					tc.stored, tc.requested, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestResolveAccessUsername_UsesConfiguredDefault(t *testing.T) {
+	config.ResetForTesting()
+	t.Cleanup(config.ResetForTesting)
+	cfg := config.Load()
+	cfg.Security.DefaultWildcardUsername = "svc-default"
+
+	got, ok := resolveAccessUsername("*")
+	if !ok {
+		t.Fatal("expected wildcard username to resolve")
+	}
+	if got != "svc-default" {
+		t.Fatalf("resolveAccessUsername(*) = %q, want %q", got, "svc-default")
+	}
+}
+
+func TestTCPProxyRejectsJITMFAProtectedAccess(t *testing.T) {
+	db := newTestDB(t)
+	user := mustCreateUser(t, db, "alice", models.RoleUser)
+	group := mustCreateGroup(t, db, "prod")
+	group.MFARequired = true
+	if err := db.Save(&group).Error; err != nil {
+		t.Fatalf("save group: %v", err)
+	}
+	mustAddUserToGroup(t, db, user.ID, group.ID, "member")
+	mustCreateGroupAccess(t, db, group.ID, "deploy", "myserver", 22)
+	mustCreateGroupEgressKey(t, db, group.ID)
+
+	err := TCPProxy(db, user, *slog.Default(), "myserver", "22")
+	if err == nil {
+		t.Fatal("expected TCPProxy to reject JIT MFA protected access")
+	}
+	if !strings.Contains(err.Error(), "requires JIT MFA") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/commands/totp/disable_totp.go
+++ b/internal/commands/totp/disable_totp.go
@@ -50,6 +50,7 @@ func DisableTOTP(db *gorm.DB, user *models.User, log *slog.Logger) error {
 
 	user.TOTPSecret = ""
 	user.TOTPEnabled = false
+	user.BackupCodes = ""
 	if err := db.Save(user).Error; err != nil {
 		return fmt.Errorf("failed to save TOTP settings: %w", err)
 	}

--- a/internal/commands/tty/list.go
+++ b/internal/commands/tty/list.go
@@ -81,12 +81,12 @@ func List(db *gorm.DB, u *models.User, args []string) error {
 	if _, err := os.Stat(baseDir); os.IsNotExist(err) {
 		console.DisplayBlock(console.ContentBlock{
 			Title:     "TTY Session List",
-			BlockType: "error",
+			BlockType: "info",
 			Sections: []console.SectionContent{
 				{SubTitle: "Not Found", Body: []string{fmt.Sprintf("User %s hasn't recorded any sessions.", username)}},
 			},
 		})
-		return err
+		return nil
 	}
 
 	var output []string
@@ -101,13 +101,6 @@ func List(db *gorm.DB, u *models.User, args []string) error {
 			}
 			filesByDate := make(map[string][]string)
 			files, err := os.ReadDir(path)
-			if err != nil {
-				return nil
-			}
-			if err := normalizeLegacyTTYRecs(path, files); err != nil {
-				return err
-			}
-			files, err = os.ReadDir(path)
 			if err != nil {
 				return nil
 			}

--- a/internal/commands/tty/list_test.go
+++ b/internal/commands/tty/list_test.go
@@ -1,9 +1,12 @@
 package tty
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/glebarez/sqlite"
+	"goBastion/internal/config"
 	"gorm.io/gorm"
 
 	"goBastion/internal/models"
@@ -33,7 +36,49 @@ func TestList_NoArgs(t *testing.T) {
 		t.Fatalf("create user: %v", err)
 	}
 
-	// No recordings dir exists; List should not panic.
-	// It returns an error (os.Stat fails) but must not panic.
-	_ = List(db, &user, []string{})
+	cfg := config.Get()
+	copyCfg := *cfg
+	copyCfg.Paths = cfg.Paths
+	copyCfg.Paths.TtyrecDir = filepath.Join(t.TempDir(), "ttyrec")
+	config.SetForTesting(&copyCfg)
+	t.Cleanup(func() { config.SetForTesting(cfg) })
+
+	if err := List(db, &user, []string{}); err != nil {
+		t.Fatalf("expected no error when recordings dir is missing, got %v", err)
+	}
+}
+
+func TestList_DoesNotMutateLegacyTTYRecs(t *testing.T) {
+	db := newTestDB(t)
+	user := models.User{Username: "alice", Role: models.RoleUser, Enabled: true}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	baseDir := filepath.Join(t.TempDir(), "ttyrec")
+	serverDir := filepath.Join(baseDir, "alice", "db.example.internal")
+	if err := os.MkdirAll(serverDir, 0o755); err != nil {
+		t.Fatalf("mkdir recordings dir: %v", err)
+	}
+	rawRecording := filepath.Join(serverDir, "root.db.example.internal:22_2026-07-21_12-30-00.ttyrec")
+	if err := os.WriteFile(rawRecording, []byte("legacy ttyrec"), 0o644); err != nil {
+		t.Fatalf("write legacy ttyrec: %v", err)
+	}
+
+	cfg := config.Get()
+	copyCfg := *cfg
+	copyCfg.Paths = cfg.Paths
+	copyCfg.Paths.TtyrecDir = baseDir
+	config.SetForTesting(&copyCfg)
+	t.Cleanup(func() { config.SetForTesting(cfg) })
+
+	if err := List(db, &user, []string{}); err != nil {
+		t.Fatalf("list recordings: %v", err)
+	}
+	if _, err := os.Stat(rawRecording); err != nil {
+		t.Fatalf("expected legacy ttyrec to remain untouched, got stat error %v", err)
+	}
+	if _, err := os.Stat(rawRecording + ".gz"); !os.IsNotExist(err) {
+		t.Fatalf("expected ttyList not to create gzip file, got err=%v", err)
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,7 +50,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &n); err != nil {
 		return fmt.Errorf("duration must be a string or number: %w", err)
 	}
-	*d = Duration(n)
+	*d = Duration(time.Duration(n) * time.Second)
 	return nil
 }
 
@@ -183,7 +183,17 @@ type DBExportConfig struct {
 }
 
 type SecurityConfig struct {
-	DefaultWildcardUsername string `json:"default_wildcard_username" toml:"default_wildcard_username"`
+	DefaultWildcardUsername string                    `json:"default_wildcard_username" toml:"default_wildcard_username"`
+	GroupVisibility         GroupVisibilityConfig     `json:"group_visibility" toml:"group_visibility"`
+	EgressKeyVisibility     EgressKeyVisibilityConfig `json:"egress_key_visibility" toml:"egress_key_visibility"`
+}
+
+type GroupVisibilityConfig struct {
+	Mode string `json:"mode" toml:"mode"`
+}
+
+type EgressKeyVisibilityConfig struct {
+	Mode string `json:"mode" toml:"mode"`
 }
 
 // The following structs are simple feature toggles. Enabled defaults to true
@@ -385,6 +395,8 @@ func defaultConfig() *Config {
 		},
 		Security: SecurityConfig{
 			DefaultWildcardUsername: "root",
+			GroupVisibility:         GroupVisibilityConfig{Mode: "open"},
+			EgressKeyVisibility:     EgressKeyVisibilityConfig{Mode: "discoverable"},
 		},
 
 		// Feature toggles (defaults: on).
@@ -455,6 +467,9 @@ func Load() *Config {
 		}
 
 		global.Store(cfg)
+		models.SetRestrictedCmdsEnabled(cfg.RestrictedCmds.Enabled)
+		models.SetGroupVisibilityMode(cfg.Security.GroupVisibility.Mode)
+		models.SetEgressKeyVisibilityMode(cfg.Security.EgressKeyVisibility.Mode)
 
 		// Determine instance identity.
 		instanceID := resolveInstanceID()
@@ -509,6 +524,8 @@ func LoadFromDB(db *gorm.DB) error {
 
 	global.Store(cfg)
 	models.SetRestrictedCmdsEnabled(cfg.RestrictedCmds.Enabled)
+	models.SetGroupVisibilityMode(cfg.Security.GroupVisibility.Mode)
+	models.SetEgressKeyVisibilityMode(cfg.Security.EgressKeyVisibility.Mode)
 	slog.Info("config_loaded_from_db", slog.String("instance_id", boot.InstanceID))
 	return nil
 }
@@ -561,6 +578,8 @@ func Reload(db *gorm.DB) {
 
 	global.Store(cfg)
 	models.SetRestrictedCmdsEnabled(cfg.RestrictedCmds.Enabled)
+	models.SetGroupVisibilityMode(cfg.Security.GroupVisibility.Mode)
+	models.SetEgressKeyVisibilityMode(cfg.Security.EgressKeyVisibility.Mode)
 	slog.Debug("config_reloaded", slog.String("instance_id", boot.InstanceID))
 }
 
@@ -804,6 +823,8 @@ func ConfigDiff() []ConfigEntry {
 
 	// Security
 	add("security", "default_wildcard_username", cfg.Security.DefaultWildcardUsername, def.Security.DefaultWildcardUsername)
+	add("security", "group_visibility.mode", cfg.Security.GroupVisibility.Mode, def.Security.GroupVisibility.Mode)
+	add("security", "egress_key_visibility.mode", cfg.Security.EgressKeyVisibility.Mode, def.Security.EgressKeyVisibility.Mode)
 
 	// Feature toggles
 	add("sftp", "enabled", fmt.Sprintf("%t", cfg.SFTP.Enabled), fmt.Sprintf("%t", def.SFTP.Enabled))
@@ -856,6 +877,9 @@ func ConfigDiff() []ConfigEntry {
 // SetForTesting replaces the global config. Only for use in tests.
 func SetForTesting(cfg *Config) {
 	global.Store(cfg)
+	models.SetRestrictedCmdsEnabled(cfg.RestrictedCmds.Enabled)
+	models.SetGroupVisibilityMode(cfg.Security.GroupVisibility.Mode)
+	models.SetEgressKeyVisibilityMode(cfg.Security.EgressKeyVisibility.Mode)
 }
 
 // idleResetFn is set by the session package so that long-running interactive
@@ -888,4 +912,7 @@ func ResetForTesting() {
 	global.Store(nil)
 	defaults = nil
 	globalOnce = sync.Once{}
+	models.SetRestrictedCmdsEnabled(true)
+	models.SetGroupVisibilityMode("open")
+	models.SetEgressKeyVisibilityMode("discoverable")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -52,6 +52,12 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.Security.DefaultWildcardUsername != "root" {
 		t.Errorf("DefaultWildcardUsername = %q, want root", cfg.Security.DefaultWildcardUsername)
 	}
+	if cfg.Security.GroupVisibility.Mode != "open" {
+		t.Errorf("GroupVisibility.Mode = %q, want open", cfg.Security.GroupVisibility.Mode)
+	}
+	if cfg.Security.EgressKeyVisibility.Mode != "discoverable" {
+		t.Errorf("EgressKeyVisibility.Mode = %q, want discoverable", cfg.Security.EgressKeyVisibility.Mode)
+	}
 	if cfg.Account.MaxInactiveDays != 0 {
 		t.Errorf("MaxInactiveDays = %d, want 0", cfg.Account.MaxInactiveDays)
 	}
@@ -131,6 +137,8 @@ func TestJSONRoundTrip(t *testing.T) {
 	cfg.Account.MaxInactiveDays = 30
 	cfg.SSH.DefaultPort = 2222
 	cfg.MFA.MaxAttempts = 5
+	cfg.Security.GroupVisibility.Mode = "members"
+	cfg.Security.EgressKeyVisibility.Mode = "managers"
 
 	data, err := json.Marshal(cfg)
 	if err != nil {
@@ -150,6 +158,32 @@ func TestJSONRoundTrip(t *testing.T) {
 	}
 	if restored.MFA.MaxAttempts != 5 {
 		t.Errorf("MaxAttempts = %d, want 5", restored.MFA.MaxAttempts)
+	}
+	if restored.Security.GroupVisibility.Mode != "members" {
+		t.Errorf("GroupVisibility.Mode = %q, want members", restored.Security.GroupVisibility.Mode)
+	}
+	if restored.Security.EgressKeyVisibility.Mode != "managers" {
+		t.Errorf("EgressKeyVisibility.Mode = %q, want managers", restored.Security.EgressKeyVisibility.Mode)
+	}
+}
+
+func TestDurationUnmarshalJSON_IntegerMeansSeconds(t *testing.T) {
+	var d Duration
+	if err := json.Unmarshal([]byte("5"), &d); err != nil {
+		t.Fatalf("unmarshal integer duration: %v", err)
+	}
+	if time.Duration(d) != 5*time.Second {
+		t.Fatalf("duration = %v, want 5s", time.Duration(d))
+	}
+}
+
+func TestDurationUnmarshalJSON_StringIntegerMeansSeconds(t *testing.T) {
+	var d Duration
+	if err := json.Unmarshal([]byte(`"5"`), &d); err != nil {
+		t.Fatalf("unmarshal quoted integer duration: %v", err)
+	}
+	if time.Duration(d) != 5*time.Second {
+		t.Fatalf("duration = %v, want 5s", time.Duration(d))
 	}
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -33,7 +33,7 @@ func resolveDBConfig() (driver, dsn string) {
 	dsn = os.Getenv("DB_DSN")
 
 	// 2. Fallback to the config file written by entrypoint.sh.
-	if driver == "" {
+	if driver == "" || dsn == "" {
 		if f, err := os.Open(config.Get().Paths.DbConfFile); err == nil {
 			scanner := bufio.NewScanner(f)
 			for scanner.Scan() {
@@ -289,6 +289,22 @@ func migrate(db *gorm.DB, driver string) error {
 		`).Error; err != nil {
 			return fmt.Errorf("failed to create idx_group_access_lookup: %w", err)
 		}
+		// Composite index for self DB access lookups.
+		if err := db.Exec(`
+			CREATE INDEX IF NOT EXISTS idx_self_db_access_lookup
+			ON self_db_accesses(user_id, host, port, username, protocol)
+			WHERE deleted_at IS NULL;
+		`).Error; err != nil {
+			return fmt.Errorf("failed to create idx_self_db_access_lookup: %w", err)
+		}
+		// Composite index for group DB access lookups.
+		if err := db.Exec(`
+			CREATE INDEX IF NOT EXISTS idx_group_db_access_lookup
+			ON group_db_accesses(group_id, host, port, username, protocol)
+			WHERE deleted_at IS NULL;
+		`).Error; err != nil {
+			return fmt.Errorf("failed to create idx_group_db_access_lookup: %w", err)
+		}
 		// Composite index for user-group membership lookups.
 		if err := db.Exec(`
 			CREATE INDEX IF NOT EXISTS idx_user_group_lookup
@@ -312,6 +328,18 @@ func migrate(db *gorm.DB, driver string) error {
 			ON group_accesses(group_id, server, port, username, protocol);
 		`).Error; err != nil {
 			return fmt.Errorf("failed to create idx_group_access_lookup: %w", err)
+		}
+		if err := db.Exec(`
+			CREATE INDEX IF NOT EXISTS idx_self_db_access_lookup
+			ON self_db_accesses(user_id, host(191), port, username(191), protocol(32));
+		`).Error; err != nil {
+			return fmt.Errorf("failed to create idx_self_db_access_lookup: %w", err)
+		}
+		if err := db.Exec(`
+			CREATE INDEX IF NOT EXISTS idx_group_db_access_lookup
+			ON group_db_accesses(group_id, host(191), port, username(191), protocol(32));
+		`).Error; err != nil {
+			return fmt.Errorf("failed to create idx_group_db_access_lookup: %w", err)
 		}
 		if err := db.Exec(`
 			CREATE INDEX IF NOT EXISTS idx_user_group_lookup

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -2,7 +2,10 @@ package db
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
+
+	"goBastion/internal/config"
 )
 
 func TestInit_SQLite_InMemory(t *testing.T) {
@@ -60,5 +63,27 @@ func TestInit_Postgres_MissingDSN(t *testing.T) {
 	_, err := Init(nil, true)
 	if err == nil {
 		t.Error("expected error when DB_DRIVER=postgres and DB_DSN is empty")
+	}
+}
+
+func TestResolveDBConfig_UsesDBConfForMissingDSN(t *testing.T) {
+	t.Setenv("DB_DRIVER", "postgres")
+	_ = os.Unsetenv("DB_DSN")
+
+	tmpDir := t.TempDir()
+	dbConf := filepath.Join(tmpDir, "db.conf")
+	if err := os.WriteFile(dbConf, []byte("DB_DRIVER=mysql\nDB_DSN=host=db.example user=test\n"), 0600); err != nil {
+		t.Fatalf("write db.conf: %v", err)
+	}
+
+	cfg := config.Get()
+	cfg.Paths.DbConfFile = dbConf
+
+	driver, dsn := resolveDBConfig()
+	if driver != "postgres" {
+		t.Fatalf("driver = %q, want postgres", driver)
+	}
+	if dsn != "host=db.example user=test" {
+		t.Fatalf("dsn = %q, want fallback from db.conf", dsn)
 	}
 }

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -3,7 +3,9 @@ package models
 import (
 	"testing"
 
+	"github.com/glebarez/sqlite"
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 )
 
 func newUser(role string, enabled bool) *User {
@@ -162,4 +164,207 @@ func TestUserGroup_RoleMethods(t *testing.T) {
 			t.Errorf("role=%q: IsGuest()=%v, want %v", tc.role, ug.IsGuest(), tc.isGuest)
 		}
 	}
+}
+
+func TestVisibilityPolicies_GroupInfoAndListAll(t *testing.T) {
+	defer SetGroupVisibilityMode("open")
+	db := newRightsTestDB(t)
+	owner, member, outsider, admin, groupName := seedVisibilityTestData(t, db)
+	groupViewCmds := []string{
+		"groupInfo",
+		"groupListAccesses",
+		"groupListAliases",
+		"groupListDBAccesses",
+		"groupListDBAliases",
+	}
+
+	SetGroupVisibilityMode("open")
+	for _, cmd := range groupViewCmds {
+		if !outsider.CanDo(db, cmd, groupName) {
+			t.Fatalf("open mode should allow outsider %s", cmd)
+		}
+	}
+	if !outsider.CanListAllGroups(db) {
+		t.Fatal("open mode should allow outsider groupList --all")
+	}
+
+	SetGroupVisibilityMode("members")
+	for _, cmd := range groupViewCmds {
+		if outsider.CanDo(db, cmd, groupName) {
+			t.Fatalf("members mode should block outsider %s", cmd)
+		}
+		if !member.CanDo(db, cmd, groupName) {
+			t.Fatalf("members mode should allow member %s", cmd)
+		}
+	}
+	if outsider.CanListAllGroups(db) {
+		t.Fatal("members mode should block outsider groupList --all")
+	}
+
+	SetGroupVisibilityMode("managers")
+	for _, cmd := range groupViewCmds {
+		if member.CanDo(db, cmd, groupName) {
+			t.Fatalf("managers mode should block plain member %s", cmd)
+		}
+		if !owner.CanDo(db, cmd, groupName) {
+			t.Fatalf("managers mode should allow owner %s", cmd)
+		}
+	}
+
+	SetGroupVisibilityMode("private")
+	for _, cmd := range groupViewCmds {
+		if outsider.CanDo(db, cmd, groupName) {
+			t.Fatalf("private mode should block outsider %s", cmd)
+		}
+		if !member.CanDo(db, cmd, groupName) {
+			t.Fatalf("private mode should still allow direct member %s", cmd)
+		}
+		if !admin.CanDo(db, cmd, groupName) {
+			t.Fatalf("private mode should allow admin %s", cmd)
+		}
+	}
+}
+
+func TestVisibilityPolicies_GroupEgressKeys(t *testing.T) {
+	defer SetEgressKeyVisibilityMode("discoverable")
+	db := newRightsTestDB(t)
+	owner, member, outsider, admin, groupName := seedVisibilityTestData(t, db)
+
+	SetEgressKeyVisibilityMode("discoverable")
+	if !outsider.CanDo(db, "groupListEgressKeys", groupName) {
+		t.Fatal("discoverable mode should allow outsider egress key listing")
+	}
+
+	SetEgressKeyVisibilityMode("members")
+	if outsider.CanDo(db, "groupListEgressKeys", groupName) {
+		t.Fatal("members mode should block outsider egress key listing")
+	}
+	if !member.CanDo(db, "groupListEgressKeys", groupName) {
+		t.Fatal("members mode should allow member egress key listing")
+	}
+
+	SetEgressKeyVisibilityMode("managers")
+	if member.CanDo(db, "groupListEgressKeys", groupName) {
+		t.Fatal("managers mode should block plain member egress key listing")
+	}
+	if !owner.CanDo(db, "groupListEgressKeys", groupName) {
+		t.Fatal("managers mode should allow owner egress key listing")
+	}
+
+	SetEgressKeyVisibilityMode("private")
+	if member.CanDo(db, "groupListEgressKeys", groupName) {
+		t.Fatal("private mode should block plain member egress key listing")
+	}
+	if !owner.CanDo(db, "groupListEgressKeys", groupName) {
+		t.Fatal("private mode should allow owner egress key listing")
+	}
+	if !admin.CanDo(db, "groupListEgressKeys", groupName) {
+		t.Fatal("private mode should allow admin egress key listing")
+	}
+}
+
+func TestVisibilityPolicies_GuestGrantLists(t *testing.T) {
+	defer SetGroupVisibilityMode("open")
+	db := newRightsTestDB(t)
+	owner, member, outsider, admin, groupName := seedVisibilityTestData(t, db)
+	guest := &User{Username: "guest", Role: RoleUser, Enabled: true}
+	if err := db.Create(guest).Error; err != nil {
+		t.Fatalf("create guest: %v", err)
+	}
+	membership := UserGroup{UserID: guest.ID, GroupID: mustGroupID(t, db, groupName), Role: GroupRoleGuest}
+	if err := db.Create(&membership).Error; err != nil {
+		t.Fatalf("create guest membership: %v", err)
+	}
+
+	cmds := []string{"groupListGuestAccesses", "groupListGuestDBAccesses"}
+
+	SetGroupVisibilityMode("open")
+	for _, cmd := range cmds {
+		if !outsider.CanDo(db, cmd, groupName) {
+			t.Fatalf("open mode should allow outsider %s", cmd)
+		}
+		if !guest.CanInspectGuestGrantTarget(db, groupName, guest.Username) {
+			t.Fatalf("guest should be able to inspect own target for %s", cmd)
+		}
+		if guest.CanInspectGuestGrantTarget(db, groupName, member.Username) {
+			t.Fatalf("guest should not be able to inspect another account for %s", cmd)
+		}
+	}
+
+	SetGroupVisibilityMode("members")
+	for _, cmd := range cmds {
+		if outsider.CanDo(db, cmd, groupName) {
+			t.Fatalf("members mode should block outsider %s", cmd)
+		}
+		if !member.CanDo(db, cmd, groupName) {
+			t.Fatalf("members mode should allow member %s", cmd)
+		}
+		if !owner.CanDo(db, cmd, groupName) || !admin.CanDo(db, cmd, groupName) {
+			t.Fatalf("members mode should allow owner/admin %s", cmd)
+		}
+	}
+
+	SetGroupVisibilityMode("managers")
+	for _, cmd := range cmds {
+		if member.CanDo(db, cmd, groupName) {
+			t.Fatalf("managers mode should block plain member %s", cmd)
+		}
+		if guest.CanDo(db, cmd, groupName) {
+			t.Fatalf("managers mode should block guest %s", cmd)
+		}
+		if !owner.CanDo(db, cmd, groupName) {
+			t.Fatalf("managers mode should allow owner %s", cmd)
+		}
+	}
+}
+
+func mustGroupID(t *testing.T, db *gorm.DB, groupName string) uuid.UUID {
+	t.Helper()
+	var group Group
+	if err := db.Where("name = ?", groupName).First(&group).Error; err != nil {
+		t.Fatalf("find group %s: %v", groupName, err)
+	}
+	return group.ID
+}
+
+func newRightsTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test DB: %v", err)
+	}
+	if err := db.AutoMigrate(&User{}, &Group{}, &UserGroup{}); err != nil {
+		t.Fatalf("migrate rights test DB: %v", err)
+	}
+	return db
+}
+
+func seedVisibilityTestData(t *testing.T, db *gorm.DB) (*User, *User, *User, *User, string) {
+	t.Helper()
+	group := Group{Name: "infra"}
+	if err := db.Create(&group).Error; err != nil {
+		t.Fatalf("create group: %v", err)
+	}
+
+	owner := &User{Username: "owner", Role: RoleUser, Enabled: true}
+	member := &User{Username: "member", Role: RoleUser, Enabled: true}
+	outsider := &User{Username: "outsider", Role: RoleUser, Enabled: true}
+	admin := &User{Username: "admin", Role: RoleAdmin, Enabled: true}
+	for _, u := range []*User{owner, member, outsider, admin} {
+		if err := db.Create(u).Error; err != nil {
+			t.Fatalf("create user %s: %v", u.Username, err)
+		}
+	}
+
+	memberships := []UserGroup{
+		{UserID: owner.ID, GroupID: group.ID, Role: GroupRoleOwner},
+		{UserID: member.ID, GroupID: group.ID, Role: GroupRoleMember},
+	}
+	for _, membership := range memberships {
+		if err := db.Create(&membership).Error; err != nil {
+			t.Fatalf("create membership: %v", err)
+		}
+	}
+
+	return owner, member, outsider, admin, group.Name
 }

--- a/internal/models/rights.go
+++ b/internal/models/rights.go
@@ -118,17 +118,7 @@ func (u *User) CanDo(db *gorm.DB, right string, target string) bool {
 		return u.canDoInGroup(userGroups, target, isManagerOrAbove)
 
 	case "groupListAccesses":
-		if u.IsAdmin() {
-			return true
-		}
-		if u.IsSuperOwner() {
-			return true
-		}
-		userGroups, err := u.getGroups(db)
-		if err != nil {
-			return false
-		}
-		return u.canDoInGroup(userGroups, target, isManagerOrMember)
+		return u.CanViewGroupInfo(db, target)
 
 	case "groupAddAlias", "groupDelAlias":
 		if u.IsAdmin() {
@@ -144,17 +134,7 @@ func (u *User) CanDo(db *gorm.DB, right string, target string) bool {
 		return u.canDoInGroup(userGroups, target, isManagerOrAbove)
 
 	case "groupListAliases":
-		if u.IsAdmin() {
-			return true
-		}
-		if u.IsSuperOwner() {
-			return true
-		}
-		userGroups, err := u.getGroups(db)
-		if err != nil {
-			return false
-		}
-		return u.canDoInGroup(userGroups, target, isManagerOrMember)
+		return u.CanViewGroupInfo(db, target)
 
 	case "groupSetMFA":
 		if u.IsAdmin() {
@@ -196,17 +176,7 @@ func (u *User) CanDo(db *gorm.DB, right string, target string) bool {
 		return u.canDoInGroup(userGroups, target, isManagerOrAbove)
 
 	case "groupListGuestAccesses":
-		if u.IsAdmin() {
-			return true
-		}
-		if u.IsSuperOwner() {
-			return true
-		}
-		userGroups, err := u.getGroups(db)
-		if err != nil {
-			return false
-		}
-		return u.canDoInGroup(userGroups, target, isManagerOrMemberOrGuest)
+		return u.CanViewGuestGrantList(db, target)
 
 	// Group: DB Accesses
 	case "groupAddDBAccess", "groupDelDBAccess":
@@ -223,17 +193,7 @@ func (u *User) CanDo(db *gorm.DB, right string, target string) bool {
 		return u.canDoInGroup(userGroups, target, isManagerOrAbove)
 
 	case "groupListDBAccesses":
-		if u.IsAdmin() {
-			return true
-		}
-		if u.IsSuperOwner() {
-			return true
-		}
-		userGroups, err := u.getGroups(db)
-		if err != nil {
-			return false
-		}
-		return u.canDoInGroup(userGroups, target, isManagerOrMember)
+		return u.CanViewGroupInfo(db, target)
 
 	// Group: Guest DB Accesses
 	case "groupAddGuestDBAccess", "groupDelGuestDBAccess":
@@ -250,17 +210,7 @@ func (u *User) CanDo(db *gorm.DB, right string, target string) bool {
 		return u.canDoInGroup(userGroups, target, isManagerOrAbove)
 
 	case "groupListGuestDBAccesses":
-		if u.IsAdmin() {
-			return true
-		}
-		if u.IsSuperOwner() {
-			return true
-		}
-		userGroups, err := u.getGroups(db)
-		if err != nil {
-			return false
-		}
-		return u.canDoInGroup(userGroups, target, isManagerOrMemberOrGuest)
+		return u.CanViewGuestGrantList(db, target)
 
 	// Group: DB Aliases
 	case "groupAddDBAlias", "groupDelDBAlias":
@@ -277,17 +227,7 @@ func (u *User) CanDo(db *gorm.DB, right string, target string) bool {
 		return u.canDoInGroup(userGroups, target, isManagerOrAbove)
 
 	case "groupListDBAliases":
-		if u.IsAdmin() {
-			return true
-		}
-		if u.IsSuperOwner() {
-			return true
-		}
-		userGroups, err := u.getGroups(db)
-		if err != nil {
-			return false
-		}
-		return u.canDoInGroup(userGroups, target, isManagerOrMember)
+		return u.CanViewGroupInfo(db, target)
 
 	case "groupCreate", "groupDelete":
 		return u.IsAdmin()
@@ -305,11 +245,14 @@ func (u *User) CanDo(db *gorm.DB, right string, target string) bool {
 		}
 		return u.canDoInGroup(userGroups, target, func(ug *UserGroup) bool { return ug.IsOwner() })
 
-	case "groupInfo", "groupList":
+	case "groupInfo":
+		return u.CanViewGroupInfo(db, target)
+
+	case "groupList":
 		return true
 
 	case "groupListEgressKeys":
-		return true
+		return u.CanViewGroupEgressKeys(db, target)
 
 	// Self
 	case "selfAddAccess":

--- a/internal/models/visibility.go
+++ b/internal/models/visibility.go
@@ -1,0 +1,221 @@
+package models
+
+import (
+	"fmt"
+	"strings"
+	"sync/atomic"
+
+	"gorm.io/gorm"
+)
+
+const (
+	GroupVisibilityOpen     = "open"
+	GroupVisibilityMembers  = "members"
+	GroupVisibilityManagers = "managers"
+	GroupVisibilityPrivate  = "private"
+
+	EgressKeyVisibilityDiscoverable = "discoverable"
+	EgressKeyVisibilityMembers      = "members"
+	EgressKeyVisibilityManagers     = "managers"
+	EgressKeyVisibilityPrivate      = "private"
+)
+
+type VisibilityPolicy struct {
+	GroupVisibilityMode     string
+	EgressKeyVisibilityMode string
+}
+
+type VisibilityDeniedKind string
+
+const (
+	VisibilityDeniedGroupPolicy     VisibilityDeniedKind = "group_policy"
+	VisibilityDeniedEgressPolicy    VisibilityDeniedKind = "egress_policy"
+	VisibilityDeniedGuestOwnOnly    VisibilityDeniedKind = "guest_own_only"
+	VisibilityDeniedGlobalGroupList VisibilityDeniedKind = "group_list_all_policy"
+)
+
+var groupVisibilityMode atomic.Value
+var egressKeyVisibilityMode atomic.Value
+
+func init() {
+	groupVisibilityMode.Store(GroupVisibilityOpen)
+	egressKeyVisibilityMode.Store(EgressKeyVisibilityDiscoverable)
+}
+
+func normalizeGroupVisibilityMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case GroupVisibilityMembers, GroupVisibilityManagers, GroupVisibilityPrivate:
+		return strings.ToLower(strings.TrimSpace(mode))
+	default:
+		return GroupVisibilityOpen
+	}
+}
+
+func normalizeEgressKeyVisibilityMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case EgressKeyVisibilityMembers, EgressKeyVisibilityManagers, EgressKeyVisibilityPrivate:
+		return strings.ToLower(strings.TrimSpace(mode))
+	default:
+		return EgressKeyVisibilityDiscoverable
+	}
+}
+
+func CurrentVisibilityPolicy() VisibilityPolicy {
+	return VisibilityPolicy{
+		GroupVisibilityMode:     normalizeGroupVisibilityMode(groupVisibilityMode.Load().(string)),
+		EgressKeyVisibilityMode: normalizeEgressKeyVisibilityMode(egressKeyVisibilityMode.Load().(string)),
+	}
+}
+
+// SetGroupVisibilityMode updates the live group visibility policy.
+func SetGroupVisibilityMode(mode string) {
+	groupVisibilityMode.Store(normalizeGroupVisibilityMode(mode))
+}
+
+// SetEgressKeyVisibilityMode updates the live group egress-key visibility policy.
+func SetEgressKeyVisibilityMode(mode string) {
+	egressKeyVisibilityMode.Store(normalizeEgressKeyVisibilityMode(mode))
+}
+
+func (u *User) CanViewGroupInfo(db *gorm.DB, target string) bool {
+	if u == nil {
+		return false
+	}
+	if u.IsAdmin() || u.IsSuperOwner() {
+		return true
+	}
+
+	switch CurrentVisibilityPolicy().GroupVisibilityMode {
+	case GroupVisibilityOpen:
+		return true
+	case GroupVisibilityMembers, GroupVisibilityPrivate:
+		userGroups, err := u.getGroups(db)
+		if err != nil {
+			return false
+		}
+		return u.canDoInGroup(userGroups, target, isManagerOrMemberOrGuest)
+	case GroupVisibilityManagers:
+		userGroups, err := u.getGroups(db)
+		if err != nil {
+			return false
+		}
+		return u.canDoInGroup(userGroups, target, isManagerOrAbove)
+	default:
+		return true
+	}
+}
+
+func (u *User) CanViewGroupEgressKeys(db *gorm.DB, target string) bool {
+	if u == nil {
+		return false
+	}
+	if u.IsAdmin() || u.IsSuperOwner() {
+		return true
+	}
+
+	userGroups, err := u.getGroups(db)
+	if err != nil {
+		return false
+	}
+
+	switch CurrentVisibilityPolicy().EgressKeyVisibilityMode {
+	case EgressKeyVisibilityDiscoverable:
+		return true
+	case EgressKeyVisibilityMembers:
+		return u.canDoInGroup(userGroups, target, isManagerOrMemberOrGuest)
+	case EgressKeyVisibilityManagers:
+		return u.canDoInGroup(userGroups, target, isManagerOrAbove)
+	case EgressKeyVisibilityPrivate:
+		return u.canDoInGroup(userGroups, target, func(ug *UserGroup) bool { return ug.IsOwner() })
+	default:
+		return true
+	}
+}
+
+func (u *User) CanListAllGroups(db *gorm.DB) bool {
+	if u == nil {
+		return false
+	}
+	if u.IsAdmin() || u.IsSuperOwner() {
+		return true
+	}
+	return CurrentVisibilityPolicy().GroupVisibilityMode == GroupVisibilityOpen
+}
+
+func (u *User) CanViewGuestGrantList(db *gorm.DB, target string) bool {
+	return u.CanViewGroupInfo(db, target)
+}
+
+func (u *User) CanInspectGuestGrantTarget(db *gorm.DB, groupName, account string) bool {
+	if !u.CanViewGuestGrantList(db, groupName) {
+		return false
+	}
+	if u.IsAdmin() || u.IsSuperOwner() {
+		return true
+	}
+	userGroups, err := u.getGroups(db)
+	if err != nil {
+		return false
+	}
+	for i := range userGroups {
+		ug := &userGroups[i]
+		if ug.Group.Name != groupName {
+			continue
+		}
+		if ug.IsGuest() {
+			return strings.EqualFold(account, u.Username)
+		}
+		return true
+	}
+	return false
+}
+
+func DescribeVisibilityDenial(kind VisibilityDeniedKind, groupName, account string) []string {
+	policy := CurrentVisibilityPolicy()
+
+	switch kind {
+	case VisibilityDeniedGroupPolicy:
+		lines := []string{
+			fmt.Sprintf("You do not have permission to view group '%s' under the current visibility policy.", groupName),
+			fmt.Sprintf("Current policy: security.group_visibility.mode=%s", policy.GroupVisibilityMode),
+		}
+		switch policy.GroupVisibilityMode {
+		case GroupVisibilityMembers:
+			lines = append(lines, "Required: member, guest, manager, admin, or superowner in the target group.")
+		case GroupVisibilityManagers:
+			lines = append(lines, "Required: owner, aclkeeper, gatekeeper, admin, or superowner in the target group.")
+		case GroupVisibilityPrivate:
+			lines = append(lines, "Required: direct group membership, admin, or superowner in the target group.")
+		}
+		return lines
+
+	case VisibilityDeniedEgressPolicy:
+		lines := []string{
+			fmt.Sprintf("You do not have permission to list egress keys for group '%s'.", groupName),
+			fmt.Sprintf("Current policy: security.egress_key_visibility.mode=%s", policy.EgressKeyVisibilityMode),
+		}
+		switch policy.EgressKeyVisibilityMode {
+		case EgressKeyVisibilityMembers:
+			lines = append(lines, "Required: member, guest, manager, admin, or superowner in the target group.")
+		case EgressKeyVisibilityManagers:
+			lines = append(lines, "Required: owner, aclkeeper, gatekeeper, admin, or superowner in the target group.")
+		case EgressKeyVisibilityPrivate:
+			lines = append(lines, "Required: group owner, admin, or superowner.")
+		}
+		return lines
+
+	case VisibilityDeniedGuestOwnOnly:
+		return []string{
+			"Guest users can only view their own grants in this group.",
+			fmt.Sprintf("Requested account: %s", account),
+		}
+
+	case VisibilityDeniedGlobalGroupList:
+		return []string{
+			"You do not have permission to list all groups under the current visibility policy.",
+			fmt.Sprintf("Current policy: security.group_visibility.mode=%s", policy.GroupVisibilityMode),
+		}
+	default:
+		return []string{"Access denied under the current visibility policy."}
+	}
+}

--- a/internal/session/modes.go
+++ b/internal/session/modes.go
@@ -77,6 +77,10 @@ func Run(db *gorm.DB, log *slog.Logger) {
 			fmt.Println("⛔ This account is limited to -osh commands only. Interactive mode is disabled.")
 			return
 		}
+		if !config.Get().Interactive.Allow {
+			fmt.Println("⛔ Interactive shell is disabled by configuration.")
+			return
+		}
 		if config.Get().ForceOSHOnly.Enabled {
 			fmt.Println("⛔ Interactive shell is disabled; use -osh commands only.")
 			return
@@ -108,6 +112,10 @@ func Run(db *gorm.DB, log *slog.Logger) {
 			return
 		}
 		if isInteractive {
+			if !config.Get().Interactive.Allow {
+				fmt.Println("⛔ Interactive shell is disabled by configuration.")
+				return
+			}
 			if !checkMFA(db, &currentUser, log) {
 				return
 			}
@@ -121,10 +129,17 @@ func Run(db *gorm.DB, log *slog.Logger) {
 			log.Info("session_start", slog.String("user", currentUser.Username), slog.String("cmd", "interactive"))
 			runInteractiveMode(db, &currentUser, log, releaseSession)
 		} else {
-			// Skip TOTP for raw TCP proxy (-W) and sftp-session: no TTY, raw pipe only.
+			// sftp-session is handled separately. Raw TCP proxy (-W) cannot safely
+			// carry an MFA prompt on its byte stream, so fail closed when account
+			// MFA would otherwise be required.
 			_, _, isTCPProxy := parseTCPProxyRequest(cmd, args)
 			isSftpSession := strings.HasPrefix(cmd, "sftp-session")
-			if !isTCPProxy && !isSftpSession {
+			if isTCPProxy {
+				if msg := tcpProxyMFABlockMessage(currentUser); msg != "" {
+					fmt.Println(msg)
+					return
+				}
+			} else if !isSftpSession {
 				if !checkMFA(db, &currentUser, log) {
 					return
 				}
@@ -141,6 +156,19 @@ func Run(db *gorm.DB, log *slog.Logger) {
 			runNonInteractiveMode(db, &currentUser, log, cmd, args)
 			log.Info("session_end", slog.String("user", currentUser.Username))
 		}
+	}
+}
+
+func tcpProxyMFABlockMessage(user models.User) string {
+	switch {
+	case user.PasswordHash != "":
+		return "⛔ TCP proxy (-W) is unavailable when password MFA is enabled on your account."
+	case user.TOTPEnabled && user.TOTPSecret != "":
+		return "⛔ TCP proxy (-W) is unavailable when TOTP MFA is enabled on your account."
+	case config.Get().RequireMFA.Enabled:
+		return "⛔ TCP proxy (-W) is unavailable while global MFA enforcement is enabled."
+	default:
+		return ""
 	}
 }
 

--- a/internal/session/modes_test.go
+++ b/internal/session/modes_test.go
@@ -3,6 +3,9 @@ package session
 import (
 	"reflect"
 	"testing"
+
+	"goBastion/internal/config"
+	"goBastion/internal/models"
 )
 
 func TestParseDBRequest(t *testing.T) {
@@ -56,5 +59,39 @@ func TestParseDBRequest(t *testing.T) {
 				t.Fatalf("parseDBRequest(%q, %v) = %v, want %v", tt.cmd, tt.args, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestInteractiveAllowConfig(t *testing.T) {
+	config.ResetForTesting()
+	t.Cleanup(config.ResetForTesting)
+	cfg := config.Load()
+	if !cfg.Interactive.Allow {
+		t.Fatal("interactive.allow should default to true")
+	}
+	cfg.Interactive.Allow = false
+	if cfg.Interactive.Allow {
+		t.Fatal("expected interactive.allow to accept runtime override")
+	}
+}
+
+func TestTCPProxyMFABlockMessage(t *testing.T) {
+	config.ResetForTesting()
+	t.Cleanup(config.ResetForTesting)
+	cfg := config.Load()
+
+	if msg := tcpProxyMFABlockMessage(models.User{}); msg != "" {
+		t.Fatalf("unexpected block message without MFA: %q", msg)
+	}
+	if msg := tcpProxyMFABlockMessage(models.User{PasswordHash: "hash"}); msg == "" {
+		t.Fatal("expected password MFA block message")
+	}
+	if msg := tcpProxyMFABlockMessage(models.User{TOTPEnabled: true, TOTPSecret: "secret"}); msg == "" {
+		t.Fatal("expected TOTP MFA block message")
+	}
+
+	cfg.RequireMFA.Enabled = true
+	if msg := tcpProxyMFABlockMessage(models.User{}); msg == "" {
+		t.Fatal("expected global MFA block message")
 	}
 }

--- a/internal/startup/startup.go
+++ b/internal/startup/startup.go
@@ -25,6 +25,7 @@ import (
 // Returns an exit code: 0 = success, 1 = fatal error, 2 = usage error, 3 = no admin configured.
 func Run(db *gorm.DB, log *slog.Logger, adapter osadapter.SystemAdapter) int {
 	regenerateSSHHostKeysFlag := flag.Bool("regenerateSSHHostKeys", false, "Force-regenerate SSH host keys")
+	regenerateSFTPProxyHostKeyFlag := flag.Bool("regenerateSFTPProxyHostKey", false, "Force-regenerate the stable SFTP proxy host key")
 	firstInstallFlag := flag.Bool("firstInstall", false, "Bootstrap first admin user")
 	syncFlag := flag.Bool("sync", false, "Sync DB state to OS (DB is source of truth)")
 	dbExportFlag := flag.Bool("dbExport", false, "Export the database as an encrypted JSON envelope to stdout")
@@ -40,7 +41,15 @@ func Run(db *gorm.DB, log *slog.Logger, adapter osadapter.SystemAdapter) int {
 	case *regenerateSSHHostKeysFlag:
 		if err := sshHostKey.GenerateSSHHostKeys(db, true); err != nil {
 			log.Error("startup_failed", slog.String("reason", "regenerate_ssh_host_keys"), slog.Any("error", err))
+			return 1
 		}
+
+	case *regenerateSFTPProxyHostKeyFlag:
+		if _, _, _, err := sshHostKey.EnsureSFTPProxyHostKey(db, true); err != nil {
+			log.Error("startup_failed", slog.String("reason", "regenerate_sftp_proxy_host_key"), slog.Any("error", err))
+			return 1
+		}
+		fmt.Fprintln(os.Stderr, "✅ SFTP proxy host key regenerated.")
 
 	case *firstInstallFlag:
 		if err := createFirstAdminUser(db, log, syncer, adapter); err != nil {
@@ -246,14 +255,13 @@ func runDisableTOTP(db *gorm.DB, log *slog.Logger, username string) int {
 		return 1
 	}
 
-	if !u.TOTPEnabled && u.PasswordHash == "" && u.BackupCodes == "" {
-		fmt.Fprintf(os.Stderr, "User '%s' has no MFA configured. Nothing to do.\n", username)
+	if !u.TOTPEnabled && u.TOTPSecret == "" && u.BackupCodes == "" {
+		fmt.Fprintf(os.Stderr, "User '%s' has no TOTP or backup codes configured. Nothing to do.\n", username)
 		return 0
 	}
 
 	u.TOTPSecret = ""
 	u.TOTPEnabled = false
-	u.PasswordHash = ""
 	u.BackupCodes = ""
 	if err := db.Save(&u).Error; err != nil {
 		fmt.Fprintf(os.Stderr, "Error: failed to update user: %v\n", err)

--- a/internal/startup/startup_test.go
+++ b/internal/startup/startup_test.go
@@ -1,6 +1,10 @@
 package startup
 
 import (
+	"io"
+	"log/slog"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/glebarez/sqlite"
@@ -8,6 +12,7 @@ import (
 
 	cmdaccount "goBastion/internal/commands/account"
 	"goBastion/internal/models"
+	"goBastion/internal/osadapter"
 )
 
 const testPubKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl test-key"
@@ -72,5 +77,117 @@ func TestBootstrap_CreateDBIngressKey_Invalid(t *testing.T) {
 	err := cmdaccount.CreateDBIngressKey(db, &user, "not-a-valid-key garbage!!!")
 	if err == nil {
 		t.Fatal("expected error for invalid key, got nil")
+	}
+}
+
+func TestRunDisableTOTP_PreservesPasswordMFA(t *testing.T) {
+	db := newTestDB(t)
+	user := models.User{
+		Username:     "alice",
+		Role:         models.RoleUser,
+		Enabled:      true,
+		TOTPSecret:   "secret",
+		TOTPEnabled:  true,
+		PasswordHash: "$2a$10$abcdefghijklmnopqrstuuXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		BackupCodes:  `["hash"]`,
+	}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() {
+		os.Stderr = oldStderr
+		_ = r.Close()
+	})
+
+	code := runDisableTOTP(db, log, user.Username)
+	_ = w.Close()
+	if code != 0 {
+		t.Fatalf("runDisableTOTP exit code = %d, want 0", code)
+	}
+
+	var got models.User
+	if err := db.Where("username = ?", user.Username).First(&got).Error; err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+	if got.PasswordHash == "" {
+		t.Fatal("password MFA should be preserved by --disableTOTP")
+	}
+	if got.TOTPEnabled || got.TOTPSecret != "" {
+		t.Fatal("TOTP should be disabled and secret cleared")
+	}
+	if got.BackupCodes != "" {
+		t.Fatal("backup codes should be cleared")
+	}
+}
+
+func TestRunDisableTOTP_NoTOTPConfiguredMessage(t *testing.T) {
+	db := newTestDB(t)
+	user := models.User{
+		Username:     "bob",
+		Role:         models.RoleUser,
+		Enabled:      true,
+		PasswordHash: "password-still-set",
+	}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() {
+		os.Stderr = oldStderr
+		_ = r.Close()
+	})
+
+	code := runDisableTOTP(db, log, user.Username)
+	_ = w.Close()
+	if code != 0 {
+		t.Fatalf("runDisableTOTP exit code = %d, want 0", code)
+	}
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	if !strings.Contains(string(out), "no TOTP or backup codes configured") {
+		t.Fatalf("unexpected message: %q", string(out))
+	}
+}
+
+type noopAdapter struct{}
+
+func (noopAdapter) CreateUser(string) error                       { return nil }
+func (noopAdapter) DeleteUser(string) error                       { return nil }
+func (noopAdapter) UpdateSudoers(*models.User) error              { return nil }
+func (noopAdapter) ChownDir(models.User, string) error            { return nil }
+func (noopAdapter) ExecCommand(string, ...string) (string, error) { return "", nil }
+func (noopAdapter) UserHomeExists(string) bool                    { return true }
+
+var _ osadapter.SystemAdapter = noopAdapter{}
+
+func TestRunRegenerateSSHHostKeysFailureReturnsError(t *testing.T) {
+	db := newTestDB(t)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	oldArgs := os.Args
+	os.Args = []string{"goBastion", "--regenerateSSHHostKeys"}
+	t.Cleanup(func() { os.Args = oldArgs })
+
+	code := Run(db, log, noopAdapter{})
+	if code == 0 {
+		t.Fatal("expected non-zero exit code when host key regeneration fails")
 	}
 }

--- a/internal/utils/autocomplete/autocomplete.go
+++ b/internal/utils/autocomplete/autocomplete.go
@@ -42,6 +42,15 @@ func Completion(d prompt.Document, user *models.User, db *gorm.DB) []prompt.Sugg
 			if (cmd == "ttyList" || cmd == "ttyPlay") && user.IsAdmin() {
 				args = append(args, prompt.Suggest{Text: "--user", Description: "Username (Admin only)"})
 			}
+			if cmd == "groupList" && !user.CanListAllGroups(db) {
+				var filtered []prompt.Suggest
+				for _, arg := range args {
+					if arg.Text != "--all" {
+						filtered = append(filtered, arg)
+					}
+				}
+				args = filtered
+			}
 			return prompt.FilterHasPrefix(filterAlreadyUsed(args), d.GetWordBeforeCursor(), true)
 		}
 	}

--- a/internal/utils/autocomplete/autocomplete_test.go
+++ b/internal/utils/autocomplete/autocomplete_test.go
@@ -1,0 +1,65 @@
+package autocomplete
+
+import (
+	"testing"
+
+	appconfig "goBastion/internal/config"
+	"goBastion/internal/models"
+
+	"github.com/c-bata/go-prompt"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestCompletionHidesGroupListAllWhenPolicyBlocksIt(t *testing.T) {
+	cfg := appconfig.DefaultConfig()
+	cfg.Security.GroupVisibility.Mode = "members"
+	appconfig.SetForTesting(cfg)
+	defer appconfig.ResetForTesting()
+
+	db := newAutocompleteTestDB(t)
+	user := &models.User{Username: "alice", Role: models.RoleUser, Enabled: true}
+	buf := prompt.NewBuffer()
+	buf.InsertText("groupList --a", false, true)
+	suggestions := Completion(*buf.Document(), user, db)
+	for _, s := range suggestions {
+		if s.Text == "--all" {
+			t.Fatal("unexpected --all suggestion when group visibility blocks global listing")
+		}
+	}
+}
+
+func TestCompletionShowsGroupListAllWhenPolicyAllowsIt(t *testing.T) {
+	cfg := appconfig.DefaultConfig()
+	cfg.Security.GroupVisibility.Mode = "open"
+	appconfig.SetForTesting(cfg)
+	defer appconfig.ResetForTesting()
+
+	db := newAutocompleteTestDB(t)
+	user := &models.User{Username: "alice", Role: models.RoleUser, Enabled: true}
+	buf := prompt.NewBuffer()
+	buf.InsertText("groupList --a", false, true)
+	suggestions := Completion(*buf.Document(), user, db)
+	found := false
+	for _, s := range suggestions {
+		if s.Text == "--all" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected --all suggestion when group visibility is open")
+	}
+}
+
+func newAutocompleteTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test DB: %v", err)
+	}
+	if err := db.AutoMigrate(&models.User{}, &models.Group{}, &models.UserGroup{}, &models.RestrictedCommandGrant{}); err != nil {
+		t.Fatalf("migrate autocomplete test DB: %v", err)
+	}
+	return db
+}

--- a/internal/utils/dbConnector/dbConnector.go
+++ b/internal/utils/dbConnector/dbConnector.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"os"
 	"os/exec"
@@ -89,6 +90,9 @@ func Connect(db *gorm.DB, user models.User, access models.DBAccessRight) error {
 	dir := fmt.Sprintf("%s/%s/%s/", config.Get().Paths.TtyrecDir, safeUser, safeHost)
 	if err := os.MkdirAll(dir, 02770); err != nil {
 		return fmt.Errorf("error creating ttyrec dir: %w", err)
+	}
+	if chmodErr := os.Chmod(dir, 02770); chmodErr != nil {
+		slog.Warn("ttyrec dir chmod failed", "dir", dir, "err", chmodErr)
 	}
 
 	filenameSuffix := ""

--- a/internal/utils/dbConnector/dbConnector_test.go
+++ b/internal/utils/dbConnector/dbConnector_test.go
@@ -100,6 +100,78 @@ func TestConnectWrapsDBClientWithTTYRec(t *testing.T) {
 	}
 }
 
+func TestConnectFixesTTYRecDirPermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	ttyrecDir := filepath.Join(tmpDir, "ttyrec")
+	ttyrecLog := filepath.Join(tmpDir, "ttyrec.args")
+	clientLog := filepath.Join(tmpDir, "client.args")
+	targetDir := filepath.Join(ttyrecDir, "alice", "db.example.internal")
+
+	for _, dir := range []string{binDir, ttyrecDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.MkdirAll(targetDir, 0o750); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+
+	ttyrecScript := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$@\" > \"" + ttyrecLog + "\"\n" +
+		"file=''\n" +
+		"if [ \"$1\" = '-f' ]; then\n" +
+		"  file=\"$2\"\n" +
+		"  shift 2\n" +
+		"fi\n" +
+		"if [ \"$1\" = '--' ]; then\n" +
+		"  shift\n" +
+		"fi\n" +
+		"printf 'ttyrec output' > \"$file\"\n" +
+		"exec \"$@\"\n"
+	if err := os.WriteFile(filepath.Join(binDir, "ttyrec"), []byte(ttyrecScript), 0o755); err != nil {
+		t.Fatalf("write ttyrec stub: %v", err)
+	}
+
+	clientScript := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$@\" > \"" + clientLog + "\"\n"
+	if err := os.WriteFile(filepath.Join(binDir, "mariadb"), []byte(clientScript), 0o755); err != nil {
+		t.Fatalf("write mariadb stub: %v", err)
+	}
+
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+":"+origPath)
+
+	cfg := config.DefaultConfig()
+	cfg.TTYRec.Enabled = true
+	cfg.Paths.TtyrecDir = ttyrecDir
+	_ = config.Load()
+	config.SetForTesting(cfg)
+	defer config.ResetForTesting()
+
+	access := models.DBAccessRight{
+		Host:     "db.example.internal",
+		Port:     3306,
+		Protocol: "mysql",
+		Username: "dbuser",
+		Password: "secret",
+		Database: "appdb",
+	}
+	user := models.User{Username: "alice"}
+
+	if err := Connect(nil, user, access); err != nil {
+		t.Fatalf("Connect returned error: %v", err)
+	}
+
+	info, err := os.Stat(targetDir)
+	if err != nil {
+		t.Fatalf("stat target dir: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o770 {
+		t.Fatalf("unexpected ttyrec dir mode: got %o want 770", got)
+	}
+}
+
 func TestResolveDBAliasErrorsOnAmbiguousGroupAlias(t *testing.T) {
 	db := newAliasTestDB(t)
 	user := models.User{Username: "alice", Role: models.RoleUser, Enabled: true}

--- a/internal/utils/sftpProxy/sftpProxy.go
+++ b/internal/utils/sftpProxy/sftpProxy.go
@@ -1,8 +1,6 @@
 package sftpProxy
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
 	"fmt"
 	"io"
 	"log/slog"
@@ -15,9 +13,11 @@ import (
 	"goBastion/internal/config"
 	"goBastion/internal/models"
 	"goBastion/internal/utils"
+	"goBastion/internal/utils/sshHostKey"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
+	"gorm.io/gorm"
 )
 
 // stdinoutConn wraps os.Stdin/Stdout as net.Conn for use with ssh.NewServerConn.
@@ -44,9 +44,7 @@ func (c *stdinoutConn) SetWriteDeadline(_ time.Time) error { return nil }
 //	Host myserver
 //	  User root
 //	  ProxyCommand ssh -p 2222 -- user@bastion "sftp-session root@%h:%p"
-//	  StrictHostKeyChecking no
-//	  UserKnownHostsFile /dev/null
-func Proxy(access models.AccessRight) error {
+func Proxy(db *gorm.DB, access models.AccessRight) error {
 	// 1. Connect to the target with the egress key.
 	signer, err := ssh.ParsePrivateKey([]byte(access.PrivateKey))
 	if err != nil {
@@ -109,14 +107,11 @@ func Proxy(access models.AccessRight) error {
 		return fmt.Errorf("target stdout pipe: %w", err)
 	}
 
-	// 3. Generate an ephemeral RSA host key for our fake SSH server.
-	hostKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	// 3. Load the stable host key used by the fake SSH server presented to the
+	// local sftp client. This allows clients to pin the host key in known_hosts.
+	hostSigner, _, _, err := sshHostKey.EnsureSFTPProxyHostKey(db, false)
 	if err != nil {
-		return fmt.Errorf("generate ephemeral host key: %w", err)
-	}
-	hostSigner, err := ssh.NewSignerFromKey(hostKey)
-	if err != nil {
-		return fmt.Errorf("create host signer: %w", err)
+		return fmt.Errorf("load SFTP proxy host key: %w", err)
 	}
 
 	// 4. Present a minimal SSH server on stdin/stdout.

--- a/internal/utils/sshHostKey/sshHostKey.go
+++ b/internal/utils/sshHostKey/sshHostKey.go
@@ -1,8 +1,13 @@
 package sshHostKey
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"os"
 	"os/exec"
@@ -10,8 +15,11 @@ import (
 	"goBastion/internal/config"
 	"goBastion/internal/models"
 
+	"golang.org/x/crypto/ssh"
 	"gorm.io/gorm"
 )
+
+const sftpProxyHostKeyType = "sftp-proxy-ed25519"
 
 // sshKeysExist returns true if the SSH host key files are present on disk.
 func sshKeysExist() bool {
@@ -47,6 +55,71 @@ func GenerateSSHHostKeys(db *gorm.DB, force bool) error {
 	}
 
 	return saveSSHHostKeys(db)
+}
+
+// EnsureSFTPProxyHostKey creates or loads the stable host key used by the
+// in-band sftp-session proxy server. The key is persisted in the same table as
+// the bastion SSH host keys, but under a dedicated type.
+func EnsureSFTPProxyHostKey(db *gorm.DB, force bool) (ssh.Signer, string, string, error) {
+	key, err := loadOrCreateSFTPProxyHostKey(db, force)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	signer, err := ssh.ParsePrivateKey(key.PrivateKey)
+	if err != nil {
+		return nil, "", "", fmt.Errorf("parse persisted SFTP proxy host key: %w", err)
+	}
+	pub, _, _, _, err := ssh.ParseAuthorizedKey(key.PublicKey)
+	if err != nil {
+		return nil, "", "", fmt.Errorf("parse persisted SFTP proxy public key: %w", err)
+	}
+	publicKey := strings.TrimSpace(string(key.PublicKey))
+	fingerprint := ssh.FingerprintSHA256(pub)
+	return signer, publicKey, fingerprint, nil
+}
+
+func loadOrCreateSFTPProxyHostKey(db *gorm.DB, force bool) (*models.SshHostKey, error) {
+	var key models.SshHostKey
+	err := db.Where("type = ?", sftpProxyHostKeyType).First(&key).Error
+	switch {
+	case err == nil && !force:
+		return &key, nil
+	case err != nil && err != gorm.ErrRecordNotFound:
+		return nil, fmt.Errorf("load SFTP proxy host key: %w", err)
+	}
+
+	pub, priv, err := generateSFTPProxyHostKeyMaterial()
+	if err != nil {
+		return nil, err
+	}
+	key = models.SshHostKey{
+		Type:       sftpProxyHostKeyType,
+		PrivateKey: priv,
+		PublicKey:  pub,
+	}
+	if err := db.Save(&key).Error; err != nil {
+		return nil, fmt.Errorf("save SFTP proxy host key: %w", err)
+	}
+	return &key, nil
+}
+
+func generateSFTPProxyHostKeyMaterial() ([]byte, []byte, error) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate ed25519 host key: %w", err)
+	}
+
+	privateDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal private host key: %w", err)
+	}
+	privatePEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateDER})
+	pub, err := ssh.NewPublicKey(publicKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal public host key: %w", err)
+	}
+	return ssh.MarshalAuthorizedKey(pub), privatePEM, nil
 }
 
 // saveSSHHostKeys reads generated key files and stores them in the database.
@@ -101,7 +174,7 @@ func removeSSHHostKeys() error {
 // RestoreSSHHostKeys writes SSH host keys from the database back to disk.
 func RestoreSSHHostKeys(db *gorm.DB) error {
 	var keys []models.SshHostKey
-	result := db.Find(&keys)
+	result := db.Where("type != ?", sftpProxyHostKeyType).Find(&keys)
 
 	if result.Error != nil {
 		return result.Error

--- a/internal/utils/sshHostKey/sshHostKey_test.go
+++ b/internal/utils/sshHostKey/sshHostKey_test.go
@@ -1,0 +1,100 @@
+package sshHostKey
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+
+	"goBastion/internal/config"
+	"goBastion/internal/models"
+)
+
+func newHostKeyTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test DB: %v", err)
+	}
+	if err := db.AutoMigrate(&models.SshHostKey{}); err != nil {
+		t.Fatalf("migrate ssh_host_keys: %v", err)
+	}
+	return db
+}
+
+func TestEnsureSFTPProxyHostKey_PersistsStableKey(t *testing.T) {
+	db := newHostKeyTestDB(t)
+
+	_, publicKey1, fingerprint1, err := EnsureSFTPProxyHostKey(db, false)
+	if err != nil {
+		t.Fatalf("first EnsureSFTPProxyHostKey: %v", err)
+	}
+	_, publicKey2, fingerprint2, err := EnsureSFTPProxyHostKey(db, false)
+	if err != nil {
+		t.Fatalf("second EnsureSFTPProxyHostKey: %v", err)
+	}
+
+	if publicKey1 == "" || fingerprint1 == "" {
+		t.Fatal("expected non-empty SFTP proxy host key material")
+	}
+	if publicKey1 != publicKey2 {
+		t.Fatal("expected persisted SFTP proxy public key to remain stable")
+	}
+	if fingerprint1 != fingerprint2 {
+		t.Fatal("expected persisted SFTP proxy fingerprint to remain stable")
+	}
+}
+
+func TestEnsureSFTPProxyHostKey_ForceRegeneratesKey(t *testing.T) {
+	db := newHostKeyTestDB(t)
+
+	_, publicKey1, fingerprint1, err := EnsureSFTPProxyHostKey(db, false)
+	if err != nil {
+		t.Fatalf("initial EnsureSFTPProxyHostKey: %v", err)
+	}
+	_, publicKey2, fingerprint2, err := EnsureSFTPProxyHostKey(db, true)
+	if err != nil {
+		t.Fatalf("forced EnsureSFTPProxyHostKey: %v", err)
+	}
+
+	if publicKey1 == publicKey2 {
+		t.Fatal("expected forced regeneration to replace public key")
+	}
+	if fingerprint1 == fingerprint2 {
+		t.Fatal("expected forced regeneration to replace fingerprint")
+	}
+}
+
+func TestRestoreSSHHostKeys_IgnoresSFTPProxyHostKey(t *testing.T) {
+	db := newHostKeyTestDB(t)
+	if err := db.Create(&models.SshHostKey{
+		Type:       "ed25519",
+		PrivateKey: []byte("system-private"),
+		PublicKey:  []byte("system-public"),
+	}).Error; err != nil {
+		t.Fatalf("insert system ssh host key: %v", err)
+	}
+	if err := db.Create(&models.SshHostKey{
+		Type:       sftpProxyHostKeyType,
+		PrivateKey: []byte("private"),
+		PublicKey:  []byte("public"),
+	}).Error; err != nil {
+		t.Fatalf("insert sftp proxy host key: %v", err)
+	}
+
+	config.ResetForTesting()
+	t.Cleanup(config.ResetForTesting)
+	cfg := config.Load()
+	cfg.Paths.SshHostKeyDir = t.TempDir()
+
+	if err := RestoreSSHHostKeys(db); err != nil {
+		t.Fatalf("RestoreSSHHostKeys: %v", err)
+	}
+
+	sftpPath := filepath.Join(cfg.Paths.SshHostKeyDir, "ssh_host_"+sftpProxyHostKeyType+"_key")
+	if _, err := os.Stat(sftpPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no sshd host key file for SFTP proxy key, got err=%v", err)
+	}
+}

--- a/internal/utils/sync/sync.go
+++ b/internal/utils/sync/sync.go
@@ -70,6 +70,7 @@ func (s *Syncer) CreateUsersFromDB() error {
 		return fmt.Errorf("error reading HOME directory: %w", err)
 	}
 	if len(homeFiles) > 0 {
+		s.log.Info("skip_initial_user_sync", slog.String("reason", "home directory is not empty"), slog.String("path", config.Get().Paths.HomeBaseDir), slog.Int("entries", len(homeFiles)))
 		return nil
 	}
 

--- a/sql/mysql.sql
+++ b/sql/mysql.sql
@@ -11,7 +11,7 @@
 -- (everything except bootstrap DB connection params).
 CREATE TABLE IF NOT EXISTS bastion_instances (
     instance_id varchar(191) NOT NULL PRIMARY KEY,
-    role        longtext NOT NULL,        -- 'master' or 'slave'
+    role        varchar(32) NOT NULL DEFAULT 'master', -- 'master' or 'slave'
     config      longtext,                 -- JSON-encoded config
     created_at  datetime,
     updated_at  datetime
@@ -78,7 +78,7 @@ CREATE TABLE IF NOT EXISTS user_groups (
     KEY idx_user_groups_user_id (user_id),
     KEY idx_user_groups_group_id (group_id),
     KEY idx_user_groups_deleted_at (deleted_at),
-    KEY idx_user_group_lookup (user_id),
+    KEY idx_user_group_lookup (user_id, group_id),
     CONSTRAINT fk_user_groups_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
     CONSTRAINT fk_user_groups_group FOREIGN KEY (group_id) REFERENCES `groups`(id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
@@ -153,7 +153,7 @@ CREATE TABLE IF NOT EXISTS self_accesses (
     deleted_at      datetime,
     KEY idx_self_accesses_user_id (user_id),
     KEY idx_self_accesses_deleted_at (deleted_at),
-    KEY idx_self_access_lookup (user_id),
+    KEY idx_self_access_lookup (user_id, server(191), port, username(191), protocol(32)),
     CONSTRAINT fk_self_accesses_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -174,7 +174,7 @@ CREATE TABLE IF NOT EXISTS group_accesses (
     deleted_at      datetime,
     KEY idx_group_accesses_group_id (group_id),
     KEY idx_group_accesses_deleted_at (deleted_at),
-    KEY idx_group_access_lookup (group_id),
+    KEY idx_group_access_lookup (group_id, server(191), port, username(191), protocol(32)),
     CONSTRAINT fk_group_accesses_group FOREIGN KEY (group_id) REFERENCES `groups`(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -240,7 +240,7 @@ CREATE TABLE IF NOT EXISTS self_db_accesses (
     deleted_at      datetime,
     KEY idx_self_db_accesses_user_id (user_id),
     KEY idx_self_db_accesses_deleted_at (deleted_at),
-    KEY idx_self_db_access_lookup (user_id),
+    KEY idx_self_db_access_lookup (user_id, host(191), port, username(191), protocol(32)),
     CONSTRAINT fk_self_db_accesses_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -265,7 +265,7 @@ CREATE TABLE IF NOT EXISTS group_db_accesses (
     deleted_at      datetime,
     KEY idx_group_db_accesses_group_id (group_id),
     KEY idx_group_db_accesses_deleted_at (deleted_at),
-    KEY idx_group_db_access_lookup (group_id),
+    KEY idx_group_db_access_lookup (group_id, host(191), port, username(191), protocol(32)),
     CONSTRAINT fk_group_db_accesses_group FOREIGN KEY (group_id) REFERENCES `groups`(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 


### PR DESCRIPTION
  - fixes inconsistent error handling in mutating `account`, `group`, `self`, `realm`, `restricted`, and `tty` commands
  - adds configurable group and egress-key visibility policies
  - tightens MFA-related behavior on passthrough and recovery flows
  - stabilizes SFTP proxy host key handling and updates the admin documentation
  - aligns config/runtime behavior, tests, and MySQL schema details with the current implementation